### PR TITLE
Replace PNG icons with SVG equivalents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
-# markdownEditor
+# Markdown Editor PWA
+
+A zero-build Progressive Web App Markdown editor designed to run directly from GitHub Pages. It offers live preview, formatting shortcuts, offline support, and Google Drive integration for opening and saving `.md` files.
+
+## Features
+
+- **Instant preview** – write Markdown in the editor and see the sanitized HTML render alongside it.
+- **Formatting toolbar** – buttons for bold, italic, headings, lists, links, images, tables, and horizontal rules.
+- **Word & character counts** – update live as you type.
+- **Offline-ready** – installable PWA with caching via a service worker.
+- **Google Drive sync** – sign in with your Google account to open and save Markdown files.
+
+## Getting started
+
+1. Clone or fork this repository.
+2. Enable GitHub Pages for the repository (Settings → Pages → Deploy from branch → `main`).
+3. Visit the published site – everything runs client-side, no build pipeline required.
+
+To work locally without a server, simply open `index.html` in a browser. For full PWA behaviour you should use a local HTTP server (for example `python -m http.server`) so that service workers can register.
+
+## Google Drive configuration
+
+Google requires that you supply your own API key and OAuth client ID for Drive access. The app stores these values in `localStorage` for reuse.
+
+1. Visit the [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a project (or choose an existing one) and enable the **Google Drive API**.
+3. Create credentials:
+   - **API key** (restrict it to the domain that will host the editor, e.g. `https://<username>.github.io`).
+   - **OAuth 2.0 Client ID** (type: Web application). Add your GitHub Pages origin to the authorised JavaScript origins.
+4. Open the editor, click **Drive settings**, and paste the API key and OAuth client ID.
+5. Click **Connect** and complete the Google sign-in flow.
+6. Use **Open** to load files from Drive and **Save** / **Save as** to write back.
+
+> ⚠️ The app requests the `drive.file` and `drive.readonly` scopes. Ensure your OAuth consent screen is configured for external users if you plan to share the app.
+
+## Project structure
+
+```
+.
+├── index.html          # Main application markup
+├── styles.css          # Layout and visual styling
+├── app.js              # Editor logic and Google Drive integration
+├── manifest.json       # PWA manifest
+├── service-worker.js   # Offline caching
+└── icons/              # PWA icons
+```
+
+## Development notes
+
+- The app persists the current document and Google credentials in the browser's `localStorage`.
+- Offline support caches the static assets; Google Drive actions require an active internet connection.
+- Because everything is static, you can fork and customise the UI without setting up a toolchain.
+
+## License
+
+[MIT](LICENSE)

--- a/app.js
+++ b/app.js
@@ -1,0 +1,620 @@
+'use strict';
+
+const editorElements = {
+  textarea: document.getElementById('markdown-input'),
+  preview: document.getElementById('preview'),
+  wordCount: document.getElementById('word-count'),
+  charCount: document.getElementById('char-count'),
+  fileIndicator: document.getElementById('current-file'),
+  statusMessage: document.getElementById('status-message'),
+  driveStatus: document.getElementById('drive-status'),
+  toolbarButtons: document.querySelectorAll('[data-action]'),
+  dialog: document.getElementById('drive-dialog'),
+  dialogClose: document.getElementById('drive-dialog-close'),
+  dialogCancel: document.getElementById('drive-dialog-cancel'),
+  dialogAlert: document.getElementById('drive-alert'),
+  driveFilesWrapper: document.getElementById('drive-files'),
+  driveFilesBody: document.getElementById('drive-files-body'),
+  driveSettingsButton: document.getElementById('drive-settings'),
+  driveConnectButton: document.getElementById('drive-connect'),
+  driveRefreshButton: document.getElementById('drive-refresh-files'),
+  driveOpenButton: document.getElementById('drive-open'),
+  driveSaveButton: document.getElementById('drive-save'),
+  driveSaveAsButton: document.getElementById('drive-save-as'),
+  driveSignInButton: document.getElementById('drive-sign-in'),
+  driveSignOutButton: document.getElementById('drive-sign-out'),
+  apiKeyInput: document.getElementById('drive-api-key'),
+  clientIdInput: document.getElementById('drive-client-id')
+};
+
+let currentFileId = null;
+let currentFileName = 'Untitled.md';
+let isDirty = true;
+let gapiReady = false;
+let gapiInitPromise = null;
+let googleAuthInstance = null;
+
+const discoveryDocs = ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'];
+const scopes = 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.file';
+
+const defaultMarkdown = `# Welcome to the Markdown Editor PWA
+
+Start typing in the editor on the left to see the rendered Markdown preview on the right. Use the toolbar buttons to quickly insert Markdown formatting such as **bold**, *italic*, links, lists, tables, and more.
+
+## Features
+
+- Live preview rendered with [Marked](https://marked.js.org/)
+- Word and character counts update automatically
+- Save your documents to Google Drive
+- Install the app to work offline as a Progressive Web App
+
+> Tip: provide your Google API key and OAuth client ID in the Drive settings dialog to enable cloud sync.
+`;
+
+function init() {
+  if (typeof marked !== 'undefined') {
+    marked.setOptions({
+      breaks: true,
+      gfm: true,
+      headerIds: true
+    });
+  }
+
+  const savedContent = localStorage.getItem('markdown-editor-content');
+  editorElements.textarea.value = savedContent ?? defaultMarkdown;
+  renderPreview(editorElements.textarea.value);
+  updateCounts(editorElements.textarea.value);
+  loadStoredCredentials();
+  restoreLastFile();
+  updateDriveButtons(false);
+  attachEventListeners();
+  registerServiceWorker();
+}
+
+function renderPreview(markdownText) {
+  if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+    editorElements.preview.textContent = markdownText;
+    return;
+  }
+
+  try {
+    const html = marked.parse(markdownText);
+    editorElements.preview.innerHTML = DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+  } catch (error) {
+    editorElements.preview.textContent = markdownText;
+    console.error('Failed to render markdown', error);
+  }
+}
+
+function updateCounts(content) {
+  const words = content.trim() ? content.trim().split(/\s+/u).length : 0;
+  const characters = content.length;
+  editorElements.wordCount.textContent = words;
+  editorElements.charCount.textContent = characters;
+}
+
+function setStatus(message, type = 'info') {
+  editorElements.statusMessage.textContent = message;
+  editorElements.statusMessage.className = '';
+  if (!message) {
+    return;
+  }
+  if (type === 'error') {
+    editorElements.statusMessage.classList.add('alert');
+  } else if (type === 'success') {
+    editorElements.statusMessage.classList.add('status-success');
+  }
+}
+
+function updateFileIndicator() {
+  const indicator = `${currentFileName}${isDirty ? ' • Unsaved changes' : ''}`;
+  editorElements.fileIndicator.textContent = indicator;
+}
+
+function attachEventListeners() {
+  editorElements.textarea.addEventListener('input', () => {
+    const value = editorElements.textarea.value;
+    renderPreview(value);
+    updateCounts(value);
+    isDirty = true;
+    localStorage.setItem('markdown-editor-content', value);
+    updateFileIndicator();
+  });
+
+  editorElements.toolbarButtons.forEach((button) => {
+    button.addEventListener('click', () => applyMarkdown(button.dataset.action));
+  });
+
+  editorElements.driveSettingsButton.addEventListener('click', () => openDialog());
+  editorElements.dialogClose.addEventListener('click', () => closeDialog());
+  editorElements.dialogCancel.addEventListener('click', () => closeDialog());
+
+  editorElements.driveConnectButton.addEventListener('click', () => {
+    saveCredentials();
+    initializeGapiClient().catch((error) => showDriveError(error));
+  });
+
+  editorElements.driveRefreshButton.addEventListener('click', () => {
+    refreshDriveFileList();
+  });
+
+  editorElements.driveOpenButton.addEventListener('click', () => {
+    openDialog();
+    refreshDriveFileList();
+  });
+
+  editorElements.driveSaveButton.addEventListener('click', () => {
+    saveToDrive();
+  });
+
+  editorElements.driveSaveAsButton.addEventListener('click', () => {
+    saveToDrive(true);
+  });
+
+  editorElements.driveSignInButton.addEventListener('click', () => {
+    signInToGoogle();
+  });
+
+  editorElements.driveSignOutButton.addEventListener('click', () => {
+    signOutOfGoogle();
+  });
+
+  editorElements.dialog.addEventListener('click', (event) => {
+    if (event.target === editorElements.dialog) {
+      closeDialog();
+    }
+  });
+}
+
+function registerServiceWorker() {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker
+        .register('service-worker.js')
+        .catch((error) => console.warn('Service worker registration failed:', error));
+    });
+  }
+}
+
+function applyMarkdown(action) {
+  const textarea = editorElements.textarea;
+  textarea.focus();
+
+  switch (action) {
+    case 'bold':
+      wrapSelection('**', '**', 'bold text');
+      break;
+    case 'italic':
+      wrapSelection('*', '*', 'italic text');
+      break;
+    case 'heading':
+      applyLinePrefix('## ');
+      break;
+    case 'link':
+      insertLink();
+      break;
+    case 'image':
+      insertImage();
+      break;
+    case 'ordered-list':
+      applyList(true);
+      break;
+    case 'unordered-list':
+      applyList(false);
+      break;
+    case 'horizontal-rule':
+      insertSnippet('\n\n---\n\n');
+      break;
+    case 'table':
+      insertSnippet('\n\n| Column 1 | Column 2 |\n| --- | --- |\n| Item 1 | Item 2 |\n\n');
+      break;
+    default:
+      break;
+  }
+}
+
+function wrapSelection(before, after, placeholder) {
+  const textarea = editorElements.textarea;
+  const { selectionStart, selectionEnd, value } = textarea;
+  const selected = value.slice(selectionStart, selectionEnd) || placeholder;
+  const newText = `${before}${selected}${after}`;
+  textarea.setRangeText(newText, selectionStart, selectionEnd, 'end');
+
+  const newStart = selectionStart + before.length;
+  const newEnd = newStart + selected.length;
+  textarea.setSelectionRange(newStart, newEnd);
+  triggerEditorUpdate();
+}
+
+function insertSnippet(snippet) {
+  const textarea = editorElements.textarea;
+  const { selectionStart, selectionEnd } = textarea;
+  textarea.setRangeText(snippet, selectionStart, selectionEnd, 'end');
+  const cursorPosition = selectionStart + snippet.length;
+  textarea.setSelectionRange(cursorPosition, cursorPosition);
+  triggerEditorUpdate();
+}
+
+function applyLinePrefix(prefix) {
+  const textarea = editorElements.textarea;
+  const { selectionStart, selectionEnd, value } = textarea;
+  const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
+  let lineEnd = value.indexOf('\n', selectionEnd);
+  if (lineEnd === -1) {
+    lineEnd = value.length;
+  }
+  const selected = value.slice(lineStart, lineEnd);
+  const lines = selected.split('\n');
+  const updatedLines = lines.map((line) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return prefix;
+    }
+    if (line.startsWith(prefix)) {
+      return line;
+    }
+    return `${prefix}${line.replace(/^#{1,6}\s+/u, '')}`;
+  });
+  const updated = updatedLines.join('\n');
+  textarea.setRangeText(updated, lineStart, lineEnd, 'end');
+  textarea.setSelectionRange(lineStart, lineStart + updated.length);
+  triggerEditorUpdate();
+}
+
+function applyList(ordered) {
+  const textarea = editorElements.textarea;
+  const { selectionStart, selectionEnd, value } = textarea;
+  const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
+  let lineEnd = value.indexOf('\n', selectionEnd);
+  if (lineEnd === -1) {
+    lineEnd = value.length;
+  }
+  const selected = value.slice(lineStart, lineEnd);
+  const lines = selected.split('\n');
+  let counter = 1;
+  const updatedLines = lines.map((line) => {
+    if (!line.trim()) {
+      return line;
+    }
+    if (ordered) {
+      const cleaned = line.replace(/^\d+\.\s+/u, '');
+      return `${counter++}. ${cleaned}`;
+    }
+    const cleaned = line.replace(/^[-*+]\s+/u, '');
+    return `- ${cleaned}`;
+  });
+  const updated = updatedLines.join('\n');
+  textarea.setRangeText(updated, lineStart, lineEnd, 'end');
+  textarea.setSelectionRange(lineStart, lineStart + updated.length);
+  triggerEditorUpdate();
+}
+
+function insertLink() {
+  const url = window.prompt('Enter the URL');
+  if (!url) {
+    return;
+  }
+  wrapSelection('[', `](${url})`, 'link text');
+}
+
+function insertImage() {
+  const url = window.prompt('Enter the image URL');
+  if (!url) {
+    return;
+  }
+  wrapSelection('![', `](${url})`, 'alt text');
+}
+
+function triggerEditorUpdate() {
+  const value = editorElements.textarea.value;
+  renderPreview(value);
+  updateCounts(value);
+  isDirty = true;
+  localStorage.setItem('markdown-editor-content', value);
+  updateFileIndicator();
+}
+
+function openDialog() {
+  clearDriveError();
+  editorElements.dialog.classList.add('active');
+  editorElements.dialog.setAttribute('aria-hidden', 'false');
+  editorElements.driveFilesWrapper.hidden = true;
+  editorElements.dialog.querySelector('input')?.focus();
+}
+
+function closeDialog() {
+  editorElements.dialog.classList.remove('active');
+  editorElements.dialog.setAttribute('aria-hidden', 'true');
+}
+
+function loadStoredCredentials() {
+  const stored = JSON.parse(localStorage.getItem('markdown-editor-drive-credentials') || '{}');
+  if (stored.apiKey) {
+    editorElements.apiKeyInput.value = stored.apiKey;
+  }
+  if (stored.clientId) {
+    editorElements.clientIdInput.value = stored.clientId;
+  }
+}
+
+function saveCredentials() {
+  const apiKey = editorElements.apiKeyInput.value.trim();
+  const clientId = editorElements.clientIdInput.value.trim();
+  if (!apiKey || !clientId) {
+    setStatus('Enter both an API key and OAuth client ID before saving.', 'error');
+    return;
+  }
+  localStorage.setItem('markdown-editor-drive-credentials', JSON.stringify({ apiKey, clientId }));
+  setStatus('Saved Google API credentials locally.', 'success');
+}
+
+function showDriveError(error) {
+  console.error(error);
+  const message = typeof error === 'string' ? error : error?.result?.error?.message || error?.message || 'Unable to complete the Google Drive request.';
+  editorElements.dialogAlert.textContent = message;
+  editorElements.dialogAlert.hidden = false;
+  setStatus(message, 'error');
+}
+
+function clearDriveError() {
+  editorElements.dialogAlert.hidden = true;
+  editorElements.dialogAlert.textContent = '';
+}
+
+function updateDriveButtons(isSignedIn) {
+  const disabled = !isSignedIn;
+  editorElements.driveOpenButton.disabled = disabled;
+  editorElements.driveSaveButton.disabled = disabled;
+  editorElements.driveSaveAsButton.disabled = disabled;
+  editorElements.driveSignInButton.hidden = isSignedIn;
+  editorElements.driveSignOutButton.hidden = !isSignedIn;
+  editorElements.driveStatus.textContent = isSignedIn ? 'Connected to Google Drive' : 'Not connected';
+}
+
+function getCredentials() {
+  const apiKey = editorElements.apiKeyInput.value.trim();
+  const clientId = editorElements.clientIdInput.value.trim();
+  if (!apiKey || !clientId) {
+    throw new Error('Provide both an API key and OAuth client ID to connect to Google Drive.');
+  }
+  return { apiKey, clientId };
+}
+
+async function initializeGapiClient() {
+  if (!gapiReady) {
+    await waitForGapi();
+  }
+  if (gapiInitPromise) {
+    return gapiInitPromise;
+  }
+
+  try {
+    const { apiKey, clientId } = getCredentials();
+    gapiInitPromise = new Promise((resolve, reject) => {
+      gapi.load('client:auth2', async () => {
+        try {
+          await gapi.client.init({
+            apiKey,
+            clientId,
+            discoveryDocs,
+            scope: scopes
+          });
+          googleAuthInstance = gapi.auth2.getAuthInstance();
+          googleAuthInstance.isSignedIn.listen(updateSigninStatus);
+          updateSigninStatus(googleAuthInstance.isSignedIn.get());
+          resolve();
+        } catch (error) {
+          gapiInitPromise = null;
+          reject(error);
+        }
+      });
+    });
+    await gapiInitPromise;
+    return;
+  } catch (error) {
+    gapiInitPromise = null;
+    throw error;
+  }
+}
+
+function updateSigninStatus(isSignedIn) {
+  updateDriveButtons(isSignedIn);
+  if (isSignedIn) {
+    setStatus('Signed in to Google Drive.', 'success');
+  } else {
+    setStatus('Signed out of Google Drive.');
+  }
+}
+
+async function waitForGapi() {
+  if (gapiReady) {
+    return;
+  }
+  await new Promise((resolve) => {
+    const check = () => {
+      if (gapiReady) {
+        resolve();
+      } else {
+        window.setTimeout(check, 100);
+      }
+    };
+    check();
+  });
+}
+
+async function ensureDriveAccess() {
+  await initializeGapiClient();
+  if (!googleAuthInstance) {
+    throw new Error('Unable to initialize Google authentication.');
+  }
+  if (!googleAuthInstance.isSignedIn.get()) {
+    await googleAuthInstance.signIn();
+  }
+}
+
+async function signInToGoogle() {
+  try {
+    await ensureDriveAccess();
+  } catch (error) {
+    showDriveError(error);
+  }
+}
+
+function signOutOfGoogle() {
+  if (googleAuthInstance) {
+    googleAuthInstance.signOut();
+  }
+}
+
+async function refreshDriveFileList() {
+  clearDriveError();
+  try {
+    await ensureDriveAccess();
+    const response = await gapi.client.drive.files.list({
+      pageSize: 50,
+      orderBy: 'modifiedTime desc',
+      q: "mimeType='text/plain' or name contains '.md'",
+      fields: 'files(id, name, modifiedTime)'
+    });
+    const files = response.result.files || [];
+    populateDriveFiles(files);
+    editorElements.driveFilesWrapper.hidden = files.length === 0;
+    if (files.length === 0) {
+      editorElements.driveFilesWrapper.hidden = true;
+      editorElements.dialogAlert.textContent = 'No compatible files found in Google Drive.';
+      editorElements.dialogAlert.hidden = false;
+    }
+  } catch (error) {
+    showDriveError(error);
+  }
+}
+
+function populateDriveFiles(files) {
+  editorElements.driveFilesBody.innerHTML = '';
+  files.forEach((file) => {
+    const row = document.createElement('tr');
+    const nameCell = document.createElement('td');
+    const modifiedCell = document.createElement('td');
+    nameCell.textContent = file.name;
+    modifiedCell.textContent = file.modifiedTime ? new Date(file.modifiedTime).toLocaleString() : '';
+    row.appendChild(nameCell);
+    row.appendChild(modifiedCell);
+    row.addEventListener('click', () => {
+      loadDriveFile(file.id, file.name);
+      closeDialog();
+    });
+    editorElements.driveFilesBody.appendChild(row);
+  });
+}
+
+async function loadDriveFile(fileId, name) {
+  try {
+    await ensureDriveAccess();
+    const response = await gapi.client.drive.files.get({ fileId, alt: 'media' });
+    const content = response.body || response.result || '';
+    editorElements.textarea.value = content;
+    renderPreview(content);
+    updateCounts(content);
+    currentFileId = fileId;
+    currentFileName = name;
+    isDirty = false;
+    updateFileIndicator();
+    localStorage.setItem('markdown-editor-content', content);
+    localStorage.setItem('markdown-editor-current-file', JSON.stringify({ id: fileId, name }));
+    setStatus(`Loaded ${name} from Google Drive.`, 'success');
+  } catch (error) {
+    showDriveError(error);
+  }
+}
+
+async function saveToDrive(forceNew = false) {
+  clearDriveError();
+  try {
+    await ensureDriveAccess();
+    let fileId = currentFileId;
+    let fileName = currentFileName;
+    if (forceNew || !fileId) {
+      const suggestedName = currentFileName || 'Untitled.md';
+      const input = window.prompt('File name', suggestedName);
+      if (!input) {
+        return;
+      }
+      fileName = input.endsWith('.md') ? input : `${input}.md`;
+      fileId = forceNew ? null : currentFileId;
+    }
+    const content = editorElements.textarea.value;
+    const result = await uploadToDrive(fileId, fileName, content);
+    currentFileId = result.id;
+    currentFileName = result.name;
+    isDirty = false;
+    updateFileIndicator();
+    localStorage.setItem('markdown-editor-current-file', JSON.stringify({ id: currentFileId, name: currentFileName }));
+    setStatus(`Saved ${currentFileName} to Google Drive.`, 'success');
+  } catch (error) {
+    showDriveError(error);
+  }
+}
+
+async function uploadToDrive(fileId, fileName, content) {
+  const boundary = '-------314159265358979323846';
+  const delimiter = `\r\n--${boundary}\r\n`;
+  const closeDelimiter = `\r\n--${boundary}--`;
+  const metadata = {
+    name: fileName,
+    mimeType: 'text/plain'
+  };
+  const multipartRequestBody =
+    delimiter +
+    'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
+    JSON.stringify(metadata) +
+    delimiter +
+    'Content-Type: text/plain\r\n\r\n' +
+    content +
+    closeDelimiter;
+
+  const path = fileId ? `/upload/drive/v3/files/${fileId}` : '/upload/drive/v3/files';
+  const method = fileId ? 'PATCH' : 'POST';
+  const request = {
+    path,
+    method,
+    params: { uploadType: 'multipart', fields: 'id,name' },
+    headers: { 'Content-Type': `multipart/related; boundary=${boundary}` },
+    body: multipartRequestBody
+  };
+
+  const response = await gapi.client.request(request);
+  return response.result;
+}
+
+function restoreLastFile() {
+  const stored = JSON.parse(localStorage.getItem('markdown-editor-current-file') || 'null');
+  if (stored?.name) {
+    currentFileName = stored.name;
+    currentFileId = stored.id || null;
+  }
+  updateFileIndicator();
+}
+
+window.onGapiLoaded = () => {
+  gapiReady = true;
+  restoreLastFile();
+};
+
+document.addEventListener('keydown', (event) => {
+  if (event.target === editorElements.textarea && event.ctrlKey) {
+    switch (event.key.toLowerCase()) {
+      case 'b':
+        event.preventDefault();
+        applyMarkdown('bold');
+        break;
+      case 'i':
+        event.preventDefault();
+        applyMarkdown('italic');
+        break;
+      default:
+        break;
+    }
+  }
+});
+
+init();

--- a/icons/icon-192.svg
+++ b/icons/icon-192.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="256" height="256" rx="48" fill="url(#bg)" />
+  <g fill="#f8fafc">
+    <rect x="72" y="52" width="32" height="152" rx="12" />
+    <rect x="152" y="52" width="32" height="152" rx="12" />
+    <rect x="52" y="96" width="152" height="32" rx="12" />
+    <rect x="52" y="140" width="152" height="32" rx="12" />
+  </g>
+  <rect x="52" y="176" width="152" height="20" rx="10" fill="#38bdf8" opacity="0.4" />
+</svg>

--- a/icons/icon-512.svg
+++ b/icons/icon-512.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="256" height="256" rx="48" fill="url(#bg)" />
+  <g fill="#f8fafc">
+    <rect x="72" y="52" width="32" height="152" rx="12" />
+    <rect x="152" y="52" width="32" height="152" rx="12" />
+    <rect x="52" y="96" width="152" height="32" rx="12" />
+    <rect x="52" y="140" width="152" height="32" rx="12" />
+  </g>
+  <rect x="52" y="176" width="152" height="20" rx="10" fill="#38bdf8" opacity="0.4" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Markdown Editor PWA</title>
+    <meta name="description" content="Progressive Web App Markdown editor with Google Drive sync." />
+    <meta name="theme-color" content="#1f2937" />
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="inner">
+        <h1>Markdown Editor PWA</h1>
+        <nav class="toolbar" aria-label="Markdown formatting">
+          <button type="button" data-action="bold" aria-label="Bold">B</button>
+          <button type="button" data-action="italic" aria-label="Italic"><em>I</em></button>
+          <button type="button" data-action="heading" aria-label="Heading">H</button>
+          <button type="button" data-action="link" aria-label="Insert link">Link</button>
+          <button type="button" data-action="image" aria-label="Insert image">Image</button>
+          <button type="button" data-action="ordered-list" aria-label="Ordered list">1.</button>
+          <button type="button" data-action="unordered-list" aria-label="Unordered list">•</button>
+          <button type="button" data-action="table" aria-label="Insert table">Table</button>
+          <button type="button" data-action="horizontal-rule" aria-label="Insert horizontal rule">HR</button>
+        </nav>
+        <div class="toolbar" aria-label="Google Drive actions">
+          <button type="button" class="secondary-button" id="drive-settings">Drive settings</button>
+          <button type="button" class="secondary-button" id="drive-sign-in">Sign in</button>
+          <button type="button" class="secondary-button" id="drive-sign-out" hidden>Sign out</button>
+          <button type="button" class="secondary-button" id="drive-open" disabled>Open</button>
+          <button type="button" class="primary" id="drive-save" disabled>Save</button>
+          <button type="button" class="secondary-button" id="drive-save-as" disabled>Save as</button>
+        </div>
+      </div>
+    </header>
+    <main>
+      <div class="editor-container">
+        <div class="editor-panels">
+          <section>
+            <textarea id="markdown-input" aria-label="Markdown input" spellcheck="true"></textarea>
+          </section>
+          <section class="preview" id="preview" aria-label="Preview" aria-live="polite"></section>
+        </div>
+        <div class="status-bar">
+          <div>
+            <span>Words: <strong id="word-count">0</strong></span>
+            <span>Characters: <strong id="char-count">0</strong></span>
+          </div>
+          <div>
+            <span class="file-indicator" id="current-file">Untitled.md</span>
+            <span id="drive-status"></span>
+          </div>
+        </div>
+        <div id="status-message" role="status" aria-live="polite"></div>
+      </div>
+    </main>
+
+    <div id="drive-dialog" role="dialog" aria-modal="true" aria-labelledby="drive-dialog-title">
+      <div class="dialog-content">
+        <div class="dialog-header">
+          <h2 id="drive-dialog-title">Google Drive</h2>
+          <button type="button" id="drive-dialog-close" aria-label="Close dialog">×</button>
+        </div>
+        <div class="dialog-body">
+          <div id="drive-alert" class="alert" hidden></div>
+          <label>
+            Google API key
+            <input type="text" id="drive-api-key" placeholder="AIza..." autocomplete="off" />
+          </label>
+          <label>
+            OAuth client ID
+            <input type="text" id="drive-client-id" placeholder="12345.apps.googleusercontent.com" autocomplete="off" />
+          </label>
+          <div class="toolbar">
+            <button type="button" id="drive-connect" class="primary">Connect</button>
+            <button type="button" id="drive-refresh-files" class="secondary-button">Refresh files</button>
+          </div>
+          <div class="drive-files" id="drive-files" hidden>
+            <table>
+              <thead>
+                <tr>
+                  <th>File</th>
+                  <th>Modified</th>
+                </tr>
+              </thead>
+              <tbody id="drive-files-body"></tbody>
+            </table>
+          </div>
+        </div>
+        <div class="dialog-footer">
+          <button type="button" id="drive-dialog-cancel">Close</button>
+        </div>
+      </div>
+    </div>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"
+      integrity="sha384-dQUsVTNff7kwh28ykVfoCENKz7dxyzKDn5XxhxL7sRKqzZo4PMBVXgS5aXoaZySU"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/dompurify@3.1.7/dist/purify.min.js"
+      integrity="sha384-4nz6Gfa1zu4MDXB0qx5kyRjO6jwxKF1u9IiMaivGi99ZTSdKCbFf8gLuwZQ+QpV5"
+      crossorigin="anonymous"
+    ></script>
+    <script src="app.js" defer></script>
+    <script async defer src="https://apis.google.com/js/api.js?onload=onGapiLoaded"></script>
+  </body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Markdown PWA Editor",
+  "short_name": "MD Editor",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#1f2937",
+  "theme_color": "#1f2937",
+  "icons": [
+    {
+      "src": "icons/icon-192.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "icons/icon-512.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,47 @@
+const CACHE_NAME = 'markdown-editor-cache-v1';
+const OFFLINE_ASSETS = [
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './manifest.json',
+  './icons/icon-192.svg',
+  './icons/icon-512.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+      return fetch(event.request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+          return response;
+        })
+        .catch(() => caches.match('./index.html'));
+    })
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,339 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --surface: rgba(15, 23, 42, 0.75);
+  --text: #e2e8f0;
+  --accent: #38bdf8;
+  --accent-dark: #0ea5e9;
+  --border: rgba(148, 163, 184, 0.4);
+  --shadow: rgba(15, 23, 42, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background: linear-gradient(160deg, #0f172a, #1e293b);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: rgba(15, 23, 42, 0.85);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 4px 12px var(--shadow);
+}
+
+header .inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+h1 {
+  font-size: 1.1rem;
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.toolbar {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.toolbar button, .toolbar .secondary-button {
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid transparent;
+  color: var(--text);
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.toolbar button:hover,
+.toolbar .secondary-button:hover {
+  background: rgba(148, 163, 184, 0.2);
+  border-color: rgba(148, 163, 184, 0.3);
+  transform: translateY(-1px);
+}
+
+.toolbar button:active,
+.toolbar .secondary-button:active {
+  transform: translateY(0);
+}
+
+.toolbar button.primary {
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.toolbar button.primary:hover {
+  background: var(--accent-dark);
+}
+
+main {
+  flex: 1;
+  width: 100%;
+}
+
+.editor-container {
+  max-width: 1200px;
+  margin: 1.5rem auto;
+  padding: 0 1.5rem 3rem;
+}
+
+.editor-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+textarea#markdown-input {
+  width: 100%;
+  min-height: 60vh;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  resize: vertical;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+}
+
+textarea#markdown-input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.preview {
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+  overflow: auto;
+}
+
+.preview h1 {
+  font-size: 2rem;
+}
+
+.preview h2 {
+  font-size: 1.7rem;
+}
+
+.preview h3 {
+  font-size: 1.4rem;
+}
+
+.preview table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1rem 0;
+}
+
+.preview table th,
+.preview table td {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 0.5rem;
+}
+
+.preview pre,
+.preview code {
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  background: rgba(15, 23, 42, 0.75);
+  padding: 0.2rem 0.35rem;
+  border-radius: 0.35rem;
+}
+
+.preview pre {
+  padding: 0.75rem 1rem;
+  overflow: auto;
+}
+
+.status-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.status-bar span {
+  margin-right: 1rem;
+}
+
+.file-indicator {
+  font-weight: 600;
+}
+
+#status-message {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+  min-height: 1.2rem;
+}
+
+#status-message.status-success {
+  color: #86efac;
+}
+
+#drive-dialog {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.75);
+  display: none;
+  place-items: center;
+  padding: 1.5rem;
+  z-index: 100;
+}
+
+#drive-dialog.active {
+  display: grid;
+}
+
+#drive-dialog .dialog-content {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  width: min(500px, 100%);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.7);
+}
+
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.dialog-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dialog-body label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.dialog-body input {
+  padding: 0.5rem 0.65rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--text);
+}
+
+.dialog-body input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.dialog-footer button {
+  padding: 0.45rem 0.8rem;
+  border-radius: 0.5rem;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.dialog-footer button.primary {
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.drive-files {
+  max-height: 200px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.drive-files table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.drive-files th,
+.drive-files td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  text-align: left;
+}
+
+.drive-files tr:hover {
+  background: rgba(56, 189, 248, 0.15);
+  cursor: pointer;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(248, 113, 113, 0.18);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+  header .inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  h1 {
+    text-align: center;
+  }
+
+  .toolbar {
+    justify-content: center;
+  }
+
+  .status-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the binary PNG icons with lightweight SVG artwork so GitHub diffs stay readable
- update the manifest, favicon link, and service worker cache list to reference the new SVG assets

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d029d0740483308e7d0db80740bdd4