### PR TITLE
Remove markdown preview pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Markdown Editor PWA
 
-A zero-build Progressive Web App Markdown editor designed to run directly from GitHub Pages. It offers live preview, formatting shortcuts, offline support, and Google Drive integration for opening and saving `.md` files.
+A zero-build Progressive Web App Markdown editor designed to run directly from GitHub Pages. It offers streamlined editing, formatting shortcuts, offline support, and Google Drive integration for opening and saving `.md` files.
 
 ## Features
 
-- **Instant preview** – write Markdown in the editor and see the sanitized HTML render alongside it.
+- **Streamlined editor** – focus on Markdown syntax with helpful toolbar shortcuts.
 - **Formatting toolbar** – buttons for bold, italic, headings, lists, links, images, tables, and horizontal rules.
 - **Word & character counts** – update live as you type.
 - **Offline-ready** – installable PWA with caching via a service worker.

--- a/index.html
+++ b/index.html
@@ -17,7 +17,9 @@
         <nav class="toolbar" aria-label="Markdown formatting">
           <button type="button" data-action="bold" aria-label="Bold">B</button>
           <button type="button" data-action="italic" aria-label="Italic"><em>I</em></button>
-          <button type="button" data-action="heading" aria-label="Heading">H</button>
+          <button type="button" data-action="heading-1" aria-label="Heading level 1">H1</button>
+          <button type="button" data-action="heading-2" aria-label="Heading level 2">H2</button>
+          <button type="button" data-action="heading-3" aria-label="Heading level 3">H3</button>
           <button type="button" data-action="link" aria-label="Insert link">Link</button>
           <button type="button" data-action="image" aria-label="Insert image">Image</button>
           <button type="button" data-action="ordered-list" aria-label="Ordered list">1.</button>
@@ -37,11 +39,8 @@
     </header>
     <main>
       <div class="editor-container">
-        <div class="editor-panels">
-          <section>
-            <textarea id="markdown-input" aria-label="Markdown input" spellcheck="true"></textarea>
-          </section>
-          <section class="preview" id="preview" aria-label="Preview" aria-live="polite"></section>
+        <div class="editor-wrapper">
+          <textarea id="markdown-input" aria-label="Markdown input" spellcheck="true"></textarea>
         </div>
         <div class="status-bar">
           <div>
@@ -95,16 +94,6 @@
       </div>
     </div>
 
-    <script
-      src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"
-      integrity="sha384-dQUsVTNff7kwh28ykVfoCENKz7dxyzKDn5XxhxL7sRKqzZo4PMBVXgS5aXoaZySU"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdn.jsdelivr.net/npm/dompurify@3.1.7/dist/purify.min.js"
-      integrity="sha384-4nz6Gfa1zu4MDXB0qx5kyRjO6jwxKF1u9IiMaivGi99ZTSdKCbFf8gLuwZQ+QpV5"
-      crossorigin="anonymous"
-    ></script>
     <script src="app.js" defer></script>
     <script async defer src="https://apis.google.com/js/api.js?onload=onGapiLoaded"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -101,10 +101,9 @@ main {
   padding: 0 1.5rem 3rem;
 }
 
-.editor-panels {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
+.editor-wrapper {
+  display: flex;
+  flex-direction: column;
 }
 
 textarea#markdown-input {
@@ -125,52 +124,6 @@ textarea#markdown-input {
 textarea#markdown-input:focus {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-}
-
-.preview {
-  padding: 1.5rem;
-  border-radius: 1rem;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid var(--border);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
-  overflow: auto;
-}
-
-.preview h1 {
-  font-size: 2rem;
-}
-
-.preview h2 {
-  font-size: 1.7rem;
-}
-
-.preview h3 {
-  font-size: 1.4rem;
-}
-
-.preview table {
-  border-collapse: collapse;
-  width: 100%;
-  margin: 1rem 0;
-}
-
-.preview table th,
-.preview table td {
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  padding: 0.5rem;
-}
-
-.preview pre,
-.preview code {
-  font-family: 'Fira Code', 'Source Code Pro', monospace;
-  background: rgba(15, 23, 42, 0.75);
-  padding: 0.2rem 0.35rem;
-  border-radius: 0.35rem;
-}
-
-.preview pre {
-  padding: 0.75rem 1rem;
-  overflow: auto;
 }
 
 .status-bar {


### PR DESCRIPTION
## Summary
- replace the single heading toolbar control with dedicated H1, H2, and H3 buttons that insert sensible defaults
- remove the markdown preview pane so the editor stands alone and simplify related styling and scripts
- update documentation and default copy to reflect the streamlined editing experience

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d123d2ba188330bd2626d0371576fd