### PR TITLE
Add inline markdown formatting directly in editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,16 @@
     <main>
       <div class="editor-container">
         <div class="editor-wrapper">
-          <textarea id="markdown-input" aria-label="Markdown input" spellcheck="true"></textarea>
+          <div class="editor-surface">
+            <div
+              id="markdown-input"
+              class="editor"
+              contenteditable="true"
+              role="textbox"
+              aria-label="Markdown input"
+              spellcheck="true"
+            ></div>
+          </div>
         </div>
         <div class="status-bar">
           <div>

--- a/styles.css
+++ b/styles.css
@@ -102,11 +102,15 @@ main {
 }
 
 .editor-wrapper {
-  display: flex;
-  flex-direction: column;
+  display: block;
 }
 
-textarea#markdown-input {
+.editor-surface {
+  position: relative;
+  min-width: 0;
+}
+
+.editor {
   width: 100%;
   min-height: 60vh;
   padding: 1rem;
@@ -114,16 +118,72 @@ textarea#markdown-input {
   background: var(--surface);
   color: var(--text);
   border: 1px solid var(--border);
-  font-family: 'Fira Code', 'Source Code Pro', monospace;
-  font-size: 0.95rem;
+  font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  font-size: 1rem;
   line-height: 1.6;
-  resize: vertical;
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+  outline: none;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  caret-color: var(--accent);
+  cursor: text;
 }
 
-textarea#markdown-input:focus {
+.editor:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+.editor-line {
+  margin: 0;
+  padding: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.editor-line.heading-1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.editor-line.heading-2 {
+  font-size: 1.45rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.editor-line.heading-3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.editor-line.heading-4 {
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.editor-line.heading-5 {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.editor-line.heading-6 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.editor .md-strong {
+  font-weight: 700;
+}
+
+.editor .md-em {
+  font-style: italic;
 }
 
 .status-bar {


### PR DESCRIPTION
## Summary
- replace the split editor/preview with a single contenteditable surface that renders markdown headings, bold, and italics inline while typing
- track selections in the new editor so toolbar actions still insert markdown syntax and Google Drive integrations operate on the underlying text
- refresh the layout and styles to support the inline-formatted editor and remove the old preview pane

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d177e743ac833085a613e68601d45a