### PR TITLE
Ensure Google API loads after app initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,6 @@
     </div>
 
     <script src="app.js" defer></script>
-    <script async defer src="https://apis.google.com/js/api.js?onload=onGapiLoaded"></script>
+    <script defer src="https://apis.google.com/js/api.js?onload=onGapiLoaded"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the async attribute from the Google API script tag so it executes after the app registers onGapiLoaded

## Testing
- manual verification

------
https://chatgpt.com/codex/tasks/task_e_68d17fc4e5948330bcd841c2c55c4a69