### PR TITLE
Switch to Google Identity Services token client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,15 @@ To work locally without a server, simply open `index.html` in a browser. For ful
 
 ## Google Drive configuration
 
-Google requires that you supply your own API key and OAuth client ID for Drive access. The app stores these values in `localStorage` for reuse.
+Google requires that you supply your own OAuth client ID (and optionally an API key) for Drive access. Configure these values via the meta tags in `index.html`.
 
 1. Visit the [Google Cloud Console](https://console.cloud.google.com/).
 2. Create a project (or choose an existing one) and enable the **Google Drive API**.
 3. Create credentials:
-   - **API key** (restrict it to the domain that will host the editor, e.g. `https://<username>.github.io`).
    - **OAuth 2.0 Client ID** (type: Web application). Add your GitHub Pages origin to the authorised JavaScript origins.
-4. Open the editor, click **Drive settings**, and paste the API key and OAuth client ID.
-5. Click **Connect** and complete the Google sign-in flow.
-6. Use **Open** to load files from Drive and **Save** / **Save as** to write back.
+   - **API key** *(optional)*. If you choose to use one, restrict it to the origin that will host the editor and copy it into the `google-api-key` meta tag.
+4. Update the placeholder value in the `<meta name="google-oauth-client-id">` tag inside `index.html` with your client ID. If you created an API key, place it in the `<meta name="google-api-key">` tag.
+5. Deploy the updated files. When you open the editor, click **Sign in** to authorise Google Drive access, then use **Open**, **Save**, or **Save as** to work with Drive files.
 
 > ⚠️ The app requests the `drive.file` and `drive.readonly` scopes. Ensure your OAuth consent screen is configured for external users if you plan to share the app.
 
@@ -47,7 +46,7 @@ Google requires that you supply your own API key and OAuth client ID for Drive a
 
 ## Development notes
 
-- The app persists the current document and Google credentials in the browser's `localStorage`.
+- The app persists the current document and last opened file in the browser's `localStorage`. Google OAuth configuration is provided via static meta tags.
 - Offline support caches the static assets; Google Drive actions require an active internet connection.
 - Because everything is static, you can fork and customise the UI without setting up a toolchain.
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <title>Markdown Editor PWA</title>
     <meta name="description" content="Progressive Web App Markdown editor with Google Drive sync." />
     <meta name="theme-color" content="#1f2937" />
+    <meta name="google-oauth-client-id" content="YOUR_GOOGLE_OAUTH_CLIENT_ID.apps.googleusercontent.com" />
+    <meta name="google-api-key" content="" />
     <link rel="manifest" href="manifest.json" />
     <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg" />
     <link rel="stylesheet" href="styles.css" />
@@ -28,7 +30,6 @@
           <button type="button" data-action="horizontal-rule" aria-label="Insert horizontal rule">HR</button>
         </nav>
         <div class="toolbar" aria-label="Google Drive actions">
-          <button type="button" class="secondary-button" id="drive-settings">Drive settings</button>
           <button type="button" class="secondary-button" id="drive-sign-in">Sign in</button>
           <button type="button" class="secondary-button" id="drive-sign-out" hidden>Sign out</button>
           <button type="button" class="secondary-button" id="drive-open" disabled>Open</button>
@@ -73,16 +74,11 @@
         </div>
         <div class="dialog-body">
           <div id="drive-alert" class="alert" hidden></div>
-          <label>
-            Google API key
-            <input type="text" id="drive-api-key" placeholder="AIza..." autocomplete="off" />
-          </label>
-          <label>
-            OAuth client ID
-            <input type="text" id="drive-client-id" placeholder="12345.apps.googleusercontent.com" autocomplete="off" />
-          </label>
+          <p id="drive-config-status" class="dialog-description">
+            Update the <code>google-oauth-client-id</code> meta tag in <code>index.html</code> with your OAuth client ID to enable
+            Drive sync.
+          </p>
           <div class="toolbar">
-            <button type="button" id="drive-connect" class="primary">Connect</button>
             <button type="button" id="drive-refresh-files" class="secondary-button">Refresh files</button>
           </div>
           <div class="drive-files" id="drive-files" hidden>
@@ -104,6 +100,12 @@
     </div>
 
     <script src="app.js" defer></script>
+    <script
+      defer
+      src="https://accounts.google.com/gsi/client"
+      onload="onGoogleAccountsLoaded()"
+      onerror="console.error('Failed to load Google Identity Services script');"
+    ></script>
     <script defer src="https://apis.google.com/js/api.js?onload=onGapiLoaded"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the Google Identity Services library and simplify the Drive dialog now that API keys are configured via meta tags
- replace the auth2 flow with a GIS token client that injects access tokens into gapi before Drive requests
- document the new configuration approach in the README

## Testing
- not run (Google authentication cannot be exercised in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d182569be08330ad81045c3d2efb0c