### PR TITLE
Handle non-HTTP cache requests and fix markdown template literal

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ Start typing in the editor to craft your Markdown documents. Use the toolbar but
 - Save your documents to Google Drive
 - Install the app to work offline as a Progressive Web App
 
-> Tip: Update the `google-oauth-client-id` meta tag in `index.html` with your OAuth client ID to enable Google Drive sync.
+> Tip: Update the \`google-oauth-client-id\` meta tag in `index.html` with your OAuth client ID to enable Google Drive sync.
 `;
 
 function init() {

--- a/service-worker.js
+++ b/service-worker.js
@@ -30,6 +30,11 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  const requestUrl = new URL(event.request.url);
+  if (requestUrl.protocol !== 'http:' && requestUrl.protocol !== 'https:') {
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then((cachedResponse) => {
       if (cachedResponse) {
@@ -37,6 +42,10 @@ self.addEventListener('fetch', (event) => {
       }
       return fetch(event.request)
         .then((response) => {
+          if (!response || response.status !== 200) {
+            return response;
+          }
+
           const responseClone = response.clone();
           caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
           return response;


### PR DESCRIPTION
## Summary
- escape the oauth client id reference in the default markdown template to keep the script valid
- guard the service worker cache logic so only HTTP(S) responses are stored

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d187eb31c48330bbd3e16f76873955