### PR TITLE
Fix gapi initialization syntax errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ Start typing in the editor to craft your Markdown documents. Use the toolbar but
 - Save your documents to Google Drive
 - Install the app to work offline as a Progressive Web App
 
-> Tip: Update the \`google-oauth-client-id\` meta tag in `index.html` with your OAuth client ID to enable Google Drive sync.
+> Tip: Update the \`google-oauth-client-id\` meta tag in \`index.html\` with your OAuth client ID to enable Google Drive sync.
 `;
 
 function init() {
@@ -754,36 +754,33 @@ async function initializeGapiClient() {
   if (gapiInitPromise) {
     return gapiInitPromise;
   }
-
-async function waitForGapi() {
-  try {
-    gapiInitPromise = gapi.client
-      .init({
-        discoveryDocs
-      })
-      .then(() => {
-        if (googleDriveConfig.apiKey) {
-          gapi.client.setApiKey(googleDriveConfig.apiKey);
-        }
-      })
-      .catch((error) => {
-        gapiInitPromise = null;
-        throw error;
-      });
-    await gapiInitPromise;
-  } catch (error) {
-    gapiInitPromise = null;
-    throw error;
+  if (typeof gapi === 'undefined' || !gapi?.client) {
+    throw new Error('Google API client library failed to load.');
   }
+  gapiInitPromise = gapi.client
+    .init({
+      discoveryDocs
+    })
+    .then(() => {
+      if (googleDriveConfig.apiKey) {
+        gapi.client.setApiKey(googleDriveConfig.apiKey);
+      }
+    })
+    .catch((error) => {
+      gapiInitPromise = null;
+      throw error;
+    });
+  await gapiInitPromise;
+  return gapiInitPromise;
 }
 
 async function waitForGapi() {
-  if (gapiReady && window.gapi) {
+  if (gapiReady && window.gapi?.client) {
     return;
   }
   await new Promise((resolve) => {
     const check = () => {
-      if (gapiReady && window.gapi) {
+      if (gapiReady && window.gapi?.client) {
         resolve();
       } else {
         window.setTimeout(check, 100);


### PR DESCRIPTION
## Summary
- complete the Google API client initialization helper and ensure it throws a clear error when the client library is missing
- deduplicate and harden the waitForGapi helper so it only resolves when the client is available
- escape the inline `index.html` reference in the default Markdown sample so the script parses correctly

## Testing
- not run (front-end only change)

------
https://chatgpt.com/codex/tasks/task_e_68d1baff0fc083308f4171ec8510564c