### PR TITLE
Load Google API client before initializing

### DIFF
--- a/app.js
+++ b/app.js
@@ -942,7 +942,19 @@ function restoreLastFile() {
 }
 
 window.onGapiLoaded = () => {
-  gapiReady = true;
+  if (typeof gapi === 'undefined' || !gapi?.load) {
+    console.error('Google API platform script loaded without gapi.load available.');
+    return;
+  }
+
+  gapi.load('client', {
+    callback: () => {
+      gapiReady = true;
+    },
+    onerror: () => {
+      console.error('Failed to load Google API client library modules.');
+    }
+  });
 };
 
 window.onGoogleAccountsLoaded = () => {


### PR DESCRIPTION
## Summary
- load the Google API client module via `gapi.load` before marking the library as ready
- add defensive logging when the Google API script is missing required APIs or fails to load modules

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1bdff1f448330af15d233c19d30c1