### PR TITLE
Enable folder navigation in Drive open/save dialogs

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,8 +78,12 @@
             Update the <code>google-oauth-client-id</code> meta tag in <code>index.html</code> with your OAuth client ID to enable
             Drive sync.
           </p>
-          <div class="toolbar">
-            <button type="button" id="drive-refresh-files" class="secondary-button">Refresh files</button>
+          <div class="drive-controls">
+            <div class="toolbar">
+              <button type="button" id="drive-refresh-files" class="secondary-button">Refresh</button>
+              <button type="button" id="drive-folder-up" class="secondary-button" disabled>Up one level</button>
+            </div>
+            <nav id="drive-breadcrumbs" class="drive-breadcrumbs" aria-label="Current folder"></nav>
           </div>
           <div class="drive-files" id="drive-files" hidden>
             <table>
@@ -91,6 +95,11 @@
               </thead>
               <tbody id="drive-files-body"></tbody>
             </table>
+          </div>
+          <div id="drive-save-controls" class="drive-save-controls" hidden>
+            <label class="visually-hidden" for="drive-file-name">File name</label>
+            <input type="text" id="drive-file-name" name="drive-file-name" placeholder="File name" autocomplete="off" />
+            <button type="button" id="drive-save-confirm" class="primary">Save here</button>
           </div>
         </div>
         <div class="dialog-footer">

--- a/styles.css
+++ b/styles.css
@@ -90,6 +90,13 @@ h1 {
   background: var(--accent-dark);
 }
 
+.toolbar button:disabled,
+.toolbar .secondary-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
 main {
   flex: 1;
   width: 100%;
@@ -319,6 +326,125 @@ main {
 .drive-files tr:hover {
   background: rgba(56, 189, 248, 0.15);
   cursor: pointer;
+}
+
+.drive-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.drive-controls .toolbar {
+  gap: 0.5rem;
+}
+
+.drive-breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.drive-breadcrumbs button {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+}
+
+.drive-breadcrumbs button:hover {
+  text-decoration: underline;
+}
+
+.drive-breadcrumbs button:disabled {
+  color: rgba(226, 232, 240, 0.6);
+  cursor: default;
+  text-decoration: none;
+}
+
+.drive-breadcrumbs .separator {
+  color: rgba(148, 163, 184, 0.6);
+  margin: 0 0.15rem;
+}
+
+.drive-files .entry-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.drive-files .entry-icon {
+  font-size: 0.95rem;
+}
+
+.drive-files tr.folder-row td {
+  font-weight: 600;
+}
+
+.drive-files tr.selected {
+  background: rgba(56, 189, 248, 0.25);
+}
+
+.drive-save-controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.drive-save-controls input {
+  flex: 1;
+}
+
+.drive-save-controls button {
+  white-space: nowrap;
+  border-radius: 0.5rem;
+  border: 1px solid transparent;
+  padding: 0.45rem 0.75rem;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.drive-save-controls button:hover {
+  background: rgba(148, 163, 184, 0.2);
+  border-color: rgba(148, 163, 184, 0.3);
+  transform: translateY(-1px);
+}
+
+.drive-save-controls button:active {
+  transform: translateY(0);
+}
+
+.drive-save-controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.drive-save-controls button.primary {
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.drive-save-controls button.primary:hover {
+  background: var(--accent-dark);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .alert {


### PR DESCRIPTION
## Summary
- add breadcrumb navigation, folder rows, and an "Up one level" control to the Google Drive dialog
- rework Save As to use the dialog with a filename input so new files can be created in any folder or overwrite selections
- update Drive helpers and styles to support the new navigation state and controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1c02d4d54833093fbe01aee4b3499