### PR TITLE
Rename app to Mark's Markdown Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Markdown Editor PWA
+# Mark's Markdown Editor
 
 A zero-build Progressive Web App Markdown editor designed to run directly from GitHub Pages. It offers streamlined editing, formatting shortcuts, offline support, and Google Drive integration for opening and saving `.md` files.
 

--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ let googleDriveConfig = {
   apiKey: ''
 };
 
-const defaultMarkdown = `# Welcome to the Markdown Editor PWA
+const defaultMarkdown = `# Welcome to Mark's Markdown Editor
 
 Start typing in the editor to craft your Markdown documents. Use the toolbar buttons to quickly insert Markdown formatting such as **bold**, *italic*, links, lists, tables, and more.
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Markdown Editor PWA</title>
+    <title>Mark's Markdown Editor</title>
     <meta name="description" content="Progressive Web App Markdown editor with Google Drive sync." />
     <meta name="theme-color" content="#1f2937" />
     <meta name="google-oauth-client-id" content="220212893778-a2ja5dvu9tkp700it2819hc6iajvbgiu.apps.googleusercontent.com" />
@@ -14,7 +14,7 @@
   <body>
     <header>
       <div class="inner">
-        <h1>Markdown Editor PWA</h1>
+        <h1>Mark's Markdown Editor</h1>
         <nav class="toolbar" aria-label="Markdown formatting">
           <button type="button" data-action="bold" aria-label="Bold">B</button>
           <button type="button" data-action="italic" aria-label="Italic"><em>I</em></button>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Markdown PWA Editor",
-  "short_name": "MD Editor",
+  "name": "Mark's Markdown Editor",
+  "short_name": "Mark's Editor",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#1f2937",


### PR DESCRIPTION
## Summary
- rename the app branding to Mark's Markdown Editor across the UI, README, default content, and manifest

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1ccb5db6483309617d08e1c40e6b2