### PR TITLE
Fix newline handling in editor

### DIFF
--- a/app.js
+++ b/app.js
@@ -190,7 +190,13 @@ function getPlainTextFromEditor() {
   if (!editor) {
     return '';
   }
-  return (editor.textContent || '').replace(/\u200B/gu, '');
+  const lineNodes = editor.querySelectorAll('.editor-line');
+  if (lineNodes.length === 0) {
+    return (editor.textContent || '').replace(/\u200B/gu, '');
+  }
+
+  const lines = Array.from(lineNodes, (line) => (line.textContent || '').replace(/\u200B/gu, ''));
+  return lines.join('\n');
 }
 
 function getSelectionOffsets() {


### PR DESCRIPTION
## Summary
- ensure the editor derives plain text by reading individual editor lines
- fall back to previous textContent behaviour when no formatted lines are present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1cd8a67108330a4f3289ecfc44339