### PR TITLE
Fix backspace handling at line breaks

### DIFF
--- a/app.js
+++ b/app.js
@@ -445,7 +445,7 @@ function handleEditorInput() {
 }
 
 function handleEditorKeyDown(event) {
-  if (event.key !== 'Enter' || event.isComposing) {
+  if (event.isComposing) {
     return;
   }
 
@@ -454,15 +454,34 @@ function handleEditorKeyDown(event) {
     return;
   }
 
-  event.preventDefault();
+  if (event.key === 'Enter') {
+    event.preventDefault();
 
-  const { start, end } = getSelectionOffsets();
-  const before = editorContent.slice(0, start);
-  const after = editorContent.slice(end);
-  const nextContent = `${before}\n${after}`;
-  const caretPosition = start + 1;
+    const { start, end } = getSelectionOffsets();
+    const before = editorContent.slice(0, start);
+    const after = editorContent.slice(end);
+    const nextContent = `${before}\n${after}`;
+    const caretPosition = start + 1;
 
-  applyEditorUpdate(nextContent, caretPosition, caretPosition);
+    applyEditorUpdate(nextContent, caretPosition, caretPosition);
+    return;
+  }
+
+  if (event.key === 'Backspace') {
+    const { start, end } = getSelectionOffsets();
+    if (start === 0 && end === 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const deletionStart = start === end ? Math.max(0, start - 1) : start;
+    const deletionEnd = end;
+    const nextContent = `${editorContent.slice(0, deletionStart)}${editorContent.slice(deletionEnd)}`;
+    const caretPosition = deletionStart;
+
+    applyEditorUpdate(nextContent, caretPosition, caretPosition);
+  }
 }
 
 function updateSelectionCache() {


### PR DESCRIPTION
## Summary
- extend the editor keydown handler to process Backspace events
- remove the character (including newline) before the caret and keep the caret position in sync
- ensure pressing Backspace at the start of a paragraph merges it with the previous line

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d243121cf48330b241c9bd28070ba8