### PR TITLE
Add editable title input synced with Drive operations

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,16 @@
     </header>
     <main>
       <div class="editor-container">
+        <div class="file-title">
+          <label class="visually-hidden" for="file-title-input">File title</label>
+          <input
+            type="text"
+            id="file-title-input"
+            name="file-title"
+            autocomplete="off"
+            placeholder="Untitled.md"
+          />
+        </div>
         <div class="editor-wrapper">
           <div class="editor-surface">
             <div

--- a/styles.css
+++ b/styles.css
@@ -108,6 +108,37 @@ main {
   padding: 0 1.5rem 3rem;
 }
 
+.file-title {
+  margin-bottom: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.file-title input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.file-title input::placeholder {
+  color: rgba(226, 232, 240, 0.5);
+}
+
+.file-title input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.18);
+}
+
 .editor-wrapper {
   display: block;
 }


### PR DESCRIPTION
## Summary
- add an editable file title field above the markdown editor with styling that matches the app
- track a pending file name so the status bar reflects renames and Drive dialogs prefill with the latest title
- update Drive load and save flows to sync the title field, persist renamed files, and clear the unsaved indicator on success

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2447348a48330b265516e0d77f9cc