### PR TITLE
Restrict Drive scopes and limit caching

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,7 +52,8 @@ let pendingSaveFileId = null;
 let pendingSaveFileName = '';
 
 const discoveryDocs = ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'];
-const scopes = 'https://www.googleapis.com/auth/drive';
+const scopes =
+  'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly';
 
 const driveConfigEndpoint = '/config/google-drive.json';
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'markdown-editor-cache-v1';
+const CACHE_NAME = 'markdown-editor-cache-v2';
 const OFFLINE_ASSETS = [
   './',
   './index.html',
@@ -8,6 +8,10 @@ const OFFLINE_ASSETS = [
   './icons/icon-192.svg',
   './icons/icon-512.svg'
 ];
+
+const OFFLINE_ASSET_URLS = new Set(
+  OFFLINE_ASSETS.map((asset) => new URL(asset, self.location.origin).href)
+);
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -32,6 +36,14 @@ self.addEventListener('fetch', (event) => {
 
   const requestUrl = new URL(event.request.url);
   if (requestUrl.protocol !== 'http:' && requestUrl.protocol !== 'https:') {
+    return;
+  }
+
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
+
+  if (!OFFLINE_ASSET_URLS.has(requestUrl.href)) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- use the intended Google Drive drive.file and drive.readonly scopes when requesting OAuth tokens
- scope the service worker cache to known offline assets and bump the cache version to clear stale entries

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2dddd3af483308b26c2934ff316cc