### PR TITLE
Add desktop table of contents for editor headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,39 +42,50 @@
     </header>
     <main>
       <div class="editor-container">
-        <div class="file-title">
-          <label class="visually-hidden" for="file-title-input">File title</label>
-          <input
-            type="text"
-            id="file-title-input"
-            name="file-title"
-            autocomplete="off"
-            placeholder="Untitled.md"
-          />
-        </div>
-        <div class="editor-wrapper">
-          <div class="editor-surface">
-            <div
-              id="markdown-input"
-              class="editor"
-              contenteditable="true"
-              role="textbox"
-              aria-label="Markdown input"
-              spellcheck="true"
-            ></div>
+        <div class="editor-layout">
+          <nav id="table-of-contents" class="toc" aria-label="Document outline">
+            <div class="toc-header">
+              <h2>Contents</h2>
+            </div>
+            <ol id="toc-list" class="toc-list" hidden></ol>
+            <p id="toc-empty" class="toc-empty" hidden>Add headings to build a table of contents.</p>
+          </nav>
+          <div class="editor-content">
+            <div class="file-title">
+              <label class="visually-hidden" for="file-title-input">File title</label>
+              <input
+                type="text"
+                id="file-title-input"
+                name="file-title"
+                autocomplete="off"
+                placeholder="Untitled.md"
+              />
+            </div>
+            <div class="editor-wrapper">
+              <div class="editor-surface">
+                <div
+                  id="markdown-input"
+                  class="editor"
+                  contenteditable="true"
+                  role="textbox"
+                  aria-label="Markdown input"
+                  spellcheck="true"
+                ></div>
+              </div>
+            </div>
+            <div class="status-bar">
+              <div>
+                <span>Words: <strong id="word-count">0</strong></span>
+                <span>Characters: <strong id="char-count">0</strong></span>
+              </div>
+              <div>
+                <span class="file-indicator" id="current-file">Untitled.md</span>
+                <span id="drive-status"></span>
+              </div>
+            </div>
+            <div id="status-message" role="status" aria-live="polite"></div>
           </div>
         </div>
-        <div class="status-bar">
-          <div>
-            <span>Words: <strong id="word-count">0</strong></span>
-            <span>Characters: <strong id="char-count">0</strong></span>
-          </div>
-          <div>
-            <span class="file-indicator" id="current-file">Untitled.md</span>
-            <span id="drive-status"></span>
-          </div>
-        </div>
-        <div id="status-message" role="status" aria-live="polite"></div>
       </div>
     </main>
 

--- a/styles.css
+++ b/styles.css
@@ -129,6 +129,14 @@ main {
   padding: 0 1.5rem 3rem;
 }
 
+.editor-layout {
+  display: block;
+}
+
+.editor-content {
+  min-width: 0;
+}
+
 .file-title {
   margin-bottom: 0.75rem;
   display: flex;
@@ -158,6 +166,87 @@ main {
   outline-offset: 2px;
   border-color: var(--accent);
   box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.18);
+}
+
+.toc {
+  display: none;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: 0 10px 30px var(--surface-shadow);
+}
+
+.toc-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.toc-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.toc-list li {
+  margin: 0;
+}
+
+.toc-list a {
+  display: block;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.5rem;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toc-list a:hover,
+.toc-list a:focus-visible {
+  background: var(--button-bg-hover);
+  color: var(--accent);
+  outline: none;
+}
+
+.toc-level-2 {
+  padding-left: 0.75rem;
+}
+
+.toc-level-3 {
+  padding-left: 1.2rem;
+}
+
+.toc-level-4 {
+  padding-left: 1.65rem;
+}
+
+.toc-level-5 {
+  padding-left: 2.1rem;
+}
+
+.toc-level-6 {
+  padding-left: 2.55rem;
+}
+
+.toc-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
 }
 
 .editor-wrapper {
@@ -260,6 +349,23 @@ main {
 
 .file-indicator {
   font-weight: 600;
+}
+
+@media (min-width: 1024px) {
+  .editor-layout {
+    display: grid;
+    grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+    gap: 1.75rem;
+    align-items: start;
+  }
+
+  .toc {
+    display: block;
+    position: sticky;
+    top: 6.5rem;
+    max-height: calc(100vh - 7rem);
+    overflow: auto;
+  }
 }
 
 #status-message {


### PR DESCRIPTION
## Summary
- add a contents navigation area beside the editor to list document headings
- style the table of contents to appear as a sticky sidebar on desktop while remaining hidden on smaller screens
- generate stable heading anchors and refresh the outline as the markdown content changes

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2eb971cac83308d5d71b8f85f4db0