### PR TITLE
Normalize HTML whitespace before Markdown conversion

### DIFF
--- a/app.js
+++ b/app.js
@@ -194,6 +194,18 @@ function formatHtmlContentForEditor(html) {
   return formatted.join('\n').replace(/\n+$/u, '');
 }
 
+function prepareHtmlContentForConversion(html) {
+  if (!html) {
+    return '';
+  }
+
+  return html
+    .replace(/\r\n/gu, '\n')
+    .replace(/^[\t ]+(?=<)/gmu, '')
+    .replace(/\n[\t ]+(?=<)/gu, '\n')
+    .replace(/\n{3,}/gu, '\n\n');
+}
+
 function slugifyHeadingText(text) {
   return text
     .toLowerCase()
@@ -480,8 +492,9 @@ function enterHtmlMode() {
 function exitHtmlMode() {
   const previousMarkdown = markdownContent;
   const latestHtml = getHtmlEditorContent();
-  htmlContent = latestHtml;
-  const convertedMarkdown = convertHtmlToMarkdown(latestHtml);
+  const preparedHtml = prepareHtmlContentForConversion(latestHtml);
+  htmlContent = preparedHtml;
+  const convertedMarkdown = convertHtmlToMarkdown(preparedHtml);
   const hasChanged = convertedMarkdown !== previousMarkdown;
   editorMode = 'markdown';
   applyEditorUpdate(convertedMarkdown, convertedMarkdown.length, convertedMarkdown.length, {


### PR DESCRIPTION
## Summary
- add an HTML normalization helper to strip editor formatting whitespace before conversion
- use the normalized HTML when switching back to Markdown mode to prevent extra blank lines

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d3a551913483309fc8f4088576bdd6