### PR TITLE
Preserve markdown spacing when toggling editor modes

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,7 @@ let gapiReady = false;
 let gapiInitPromise = null;
 let markdownContent = '';
 let htmlContent = '';
+let lastNormalizedHtml = '';
 let editorMode = 'markdown';
 let turndownService = null;
 let lastSelection = { start: 0, end: 0 };
@@ -194,6 +195,18 @@ function formatHtmlContentForEditor(html) {
   return formatted.join('\n').replace(/\n+$/u, '');
 }
 
+function prepareHtmlContentForConversion(html) {
+  if (!html) {
+    return '';
+  }
+
+  return html
+    .replace(/\r\n/gu, '\n')
+    .replace(/^[\t ]+(?=<)/gmu, '')
+    .replace(/\n[\t ]+(?=<)/gu, '\n')
+    .replace(/\n{3,}/gu, '\n\n');
+}
+
 function slugifyHeadingText(text) {
   return text
     .toLowerCase()
@@ -210,6 +223,86 @@ function extractHeadingText(rawHeading) {
     .replace(/\[(.+?)\]\(.*?\)/gu, '$1')
     .replace(/[`*_~]/gu, '')
     .trim();
+}
+
+function createHeadingSpacingMap(markdown) {
+  const lines = (markdown || '').split('\n');
+  const spacingMap = new Map();
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^\s{0,3}(#{1,6})\s+(.*)$/u);
+    if (!match) {
+      continue;
+    }
+
+    let blankLines = 0;
+    let pointer = index + 1;
+    while (pointer < lines.length && lines[pointer].trim() === '') {
+      blankLines += 1;
+      pointer += 1;
+    }
+
+    const level = match[1].length;
+    const headingText = extractHeadingText(match[2]);
+    const key = `${level}:${headingText.toLowerCase()}`;
+    if (!spacingMap.has(key)) {
+      spacingMap.set(key, []);
+    }
+    spacingMap.get(key).push(blankLines);
+  }
+
+  return spacingMap;
+}
+
+function normalizeMarkdownHeadingSpacing(markdown, spacingMap) {
+  if (!markdown || !spacingMap?.size) {
+    return markdown;
+  }
+
+  const workingMap = new Map();
+  spacingMap.forEach((values, key) => {
+    workingMap.set(key, values.slice());
+  });
+
+  const lines = markdown.split('\n');
+  const result = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    result.push(line);
+
+    const match = line.match(/^\s{0,3}(#{1,6})\s+(.*)$/u);
+    if (match) {
+      let blankLines = 0;
+      let pointer = index + 1;
+      while (pointer < lines.length && lines[pointer].trim() === '') {
+        blankLines += 1;
+        pointer += 1;
+      }
+
+      const level = match[1].length;
+      const headingText = extractHeadingText(match[2]);
+      const key = `${level}:${headingText.toLowerCase()}`;
+      const stored = workingMap.get(key);
+      const desiredBlankLines = stored && stored.length ? stored.shift() : null;
+      const blanksToKeep =
+        desiredBlankLines === null || desiredBlankLines === undefined
+          ? blankLines
+          : Math.min(blankLines, desiredBlankLines);
+
+      for (let kept = 0; kept < blanksToKeep; kept += 1) {
+        result.push('');
+      }
+
+      index += 1 + blankLines;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return result.join('\n');
 }
 
 function generateHeadingId(text, level, slugCounts) {
@@ -453,7 +546,13 @@ function enterHtmlMode() {
   }
   const convertersReady = Boolean(window.marked?.parse) && Boolean(turndownService);
   const convertedHtml = convertMarkdownToHtml(markdownContent);
-  htmlContent = convertersReady ? formatHtmlContentForEditor(convertedHtml) : convertedHtml;
+  const formattedHtml = convertersReady
+    ? formatHtmlContentForEditor(convertedHtml)
+    : convertedHtml;
+  htmlContent = formattedHtml;
+  lastNormalizedHtml = convertersReady
+    ? prepareHtmlContentForConversion(formattedHtml)
+    : formattedHtml;
   editorMode = 'html';
   renderHtmlEditor(htmlContent);
   setToolbarDisabled(true);
@@ -480,11 +579,27 @@ function enterHtmlMode() {
 function exitHtmlMode() {
   const previousMarkdown = markdownContent;
   const latestHtml = getHtmlEditorContent();
-  htmlContent = latestHtml;
-  const convertedMarkdown = convertHtmlToMarkdown(latestHtml);
-  const hasChanged = convertedMarkdown !== previousMarkdown;
+  const preparedHtml = prepareHtmlContentForConversion(latestHtml);
+  const convertersReady = Boolean(window.marked?.parse) && Boolean(turndownService);
+  htmlContent = preparedHtml;
+
+  let nextMarkdown = previousMarkdown;
+  let hasChanged = false;
+
+  if (convertersReady) {
+    if (preparedHtml !== lastNormalizedHtml) {
+      const headingSpacingMap = createHeadingSpacingMap(previousMarkdown);
+      const convertedMarkdown = convertHtmlToMarkdown(preparedHtml);
+      nextMarkdown = normalizeMarkdownHeadingSpacing(convertedMarkdown, headingSpacingMap);
+      hasChanged = nextMarkdown !== previousMarkdown;
+    }
+  } else {
+    nextMarkdown = preparedHtml;
+    hasChanged = nextMarkdown !== previousMarkdown;
+  }
+
   editorMode = 'markdown';
-  applyEditorUpdate(convertedMarkdown, convertedMarkdown.length, convertedMarkdown.length, {
+  applyEditorUpdate(nextMarkdown, nextMarkdown.length, nextMarkdown.length, {
     focus: true,
     markDirty: hasChanged || isDirty,
     persistContent: true
@@ -495,6 +610,7 @@ function exitHtmlMode() {
     editorElements.editor.setAttribute('aria-label', 'Markdown input');
   }
   setStatus('Markdown mode enabled.', 'info');
+  lastNormalizedHtml = preparedHtml;
 }
 
 function toggleEditorMode() {


### PR DESCRIPTION
## Summary
- track the normalized HTML generated when entering HTML mode so returning without edits keeps the original Markdown unchanged
- restore the prior heading spacing when converting HTML back to Markdown to avoid adding extra blank lines below headings

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3a551913483309fc8f4088576bdd6