### PR TITLE
Revamp editor chrome with icon toolbar and polished surfaces

### DIFF
--- a/app.js
+++ b/app.js
@@ -536,7 +536,16 @@ function updateModeToggleState() {
     return;
   }
   const isHtmlMode = editorMode === 'html';
-  editorElements.modeToggle.textContent = isHtmlMode ? 'Switch to Markdown' : 'Switch to HTML';
+  const buttonLabel = editorElements.modeToggle.querySelector('.button-label');
+  const nextModeText = isHtmlMode ? 'Markdown' : 'HTML';
+  const toggleDescription = isHtmlMode ? 'Switch to Markdown mode' : 'Switch to HTML mode';
+  if (buttonLabel) {
+    buttonLabel.textContent = nextModeText;
+  } else {
+    editorElements.modeToggle.textContent = `Switch to ${nextModeText}`;
+  }
+  editorElements.modeToggle.setAttribute('aria-label', toggleDescription);
+  editorElements.modeToggle.setAttribute('title', toggleDescription);
   editorElements.modeToggle.setAttribute('aria-pressed', isHtmlMode ? 'true' : 'false');
 }
 

--- a/index.html
+++ b/index.html
@@ -17,34 +17,242 @@
   <body>
     <header>
       <div class="inner">
-        <h1>Mark's Markdown Editor</h1>
-        <nav class="toolbar" aria-label="Markdown formatting">
-          <button type="button" data-action="bold" aria-label="Bold">B</button>
-          <button type="button" data-action="italic" aria-label="Italic"><em>I</em></button>
-          <button type="button" data-action="heading-1" aria-label="Heading level 1">H1</button>
-          <button type="button" data-action="heading-2" aria-label="Heading level 2">H2</button>
-          <button type="button" data-action="heading-3" aria-label="Heading level 3">H3</button>
-          <button type="button" data-action="link" aria-label="Insert link">Link</button>
-          <button type="button" data-action="image" aria-label="Insert image">Image</button>
-          <button type="button" data-action="ordered-list" aria-label="Ordered list">1.</button>
-          <button type="button" data-action="unordered-list" aria-label="Unordered list">•</button>
-          <button type="button" data-action="table" aria-label="Insert table">Table</button>
-          <button type="button" data-action="horizontal-rule" aria-label="Insert horizontal rule">HR</button>
-          <button
-            type="button"
-            class="secondary-button"
-            id="editor-mode-toggle"
-            aria-pressed="false"
-          >
-            Switch to HTML
-          </button>
-        </nav>
-        <div class="toolbar" aria-label="Google Drive actions">
-          <button type="button" class="secondary-button" id="drive-sign-in">Sign in</button>
-          <button type="button" class="secondary-button" id="drive-sign-out" hidden>Sign out</button>
-          <button type="button" class="secondary-button" id="drive-open" disabled>Open</button>
-          <button type="button" class="primary" id="drive-save" disabled>Save</button>
-          <button type="button" class="secondary-button" id="drive-save-as" disabled>Save as</button>
+        <div class="app-brand">
+          <span class="brand-mark" aria-hidden="true">
+            <svg viewBox="0 0 32 32" role="presentation">
+              <defs>
+                <linearGradient id="brand-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#38bdf8" />
+                  <stop offset="100%" stop-color="#0ea5e9" />
+                </linearGradient>
+              </defs>
+              <rect x="2" y="2" width="28" height="28" rx="8" fill="url(#brand-gradient)" />
+              <path
+                d="M11 22.5V9.5L16 18l5-8.5v13"
+                fill="none"
+                stroke="#0f172a"
+                stroke-width="2.4"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <h1>Mark's Markdown Editor</h1>
+        </div>
+        <div class="toolbar-row">
+          <div class="toolbar toolbar-surface formatting" role="toolbar" aria-label="Markdown formatting">
+            <button type="button" class="icon-button" data-action="bold" aria-label="Bold">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7 4.75h1.75v14.5H7z" fill="currentColor" />
+                <path d="M8.75 4.75H13a3.25 3.25 0 110 6.5H8.75z" fill="currentColor" />
+                <path d="M8.75 11.25H13.5a3.25 3.25 0 110 6.5H8.75z" fill="currentColor" />
+              </svg>
+            </button>
+            <button type="button" class="icon-button" data-action="italic" aria-label="Italic">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M11 5.5h8M7 18.5h8M15 5.5l-4 13"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <button type="button" class="icon-button heading-button" data-action="heading-1" aria-label="Heading level 1">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6.5 6.5v11m6-11v11m-6-5.5h6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M17.5 9l2-1.2v9.7"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span class="toolbar-badge">1</span>
+            </button>
+            <button type="button" class="icon-button heading-button" data-action="heading-2" aria-label="Heading level 2">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6.5 6.5v11m6-11v11m-6-5.5h6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M16 10.2a2.6 2.6 0 012.6-2.7c1.4 0 2.4.9 2.4 2.1 0 1-.6 1.6-1.5 2.4l-2.6 2.2h4.1"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span class="toolbar-badge">2</span>
+            </button>
+            <button type="button" class="icon-button heading-button" data-action="heading-3" aria-label="Heading level 3">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6.5 6.5v11m6-11v11m-6-5.5h6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M16.5 10a2.4 2.4 0 012.4-2.5c1.2 0 2.1.8 2.1 1.9 0 .9-.5 1.5-1.3 1.8 1 .3 1.6 1.1 1.6 2.1 0 1.4-1.1 2.4-2.6 2.4-1.1 0-2-.6-2.5-1.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span class="toolbar-badge">3</span>
+            </button>
+            <button type="button" class="icon-button" data-action="link" aria-label="Insert link">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M9.5 14.5l-1.9 1.9a3 3 0 104.3 4.2l3.2-3.2a3 3 0 000-4.3l-.4-.4"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M14.5 9.5l1.9-1.9a3 3 0 00-4.3-4.3l-3.2 3.2a3 3 0 000 4.3l.4.4"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <button type="button" class="icon-button" data-action="image" aria-label="Insert image">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <rect
+                  x="4"
+                  y="5"
+                  width="16"
+                  height="14"
+                  rx="2"
+                  ry="2"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                />
+                <circle cx="9" cy="10" r="1.6" fill="currentColor" />
+                <path
+                  d="M7 17l3.5-3.5 2.5 2.5 3.5-3.5 3 3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <button type="button" class="icon-button" data-action="ordered-list" aria-label="Ordered list">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M10 7h9m-9 5h9m-9 5h9"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M5.5 6.5l-1.5.8M4 6.5v4.5m0 3h2.2L4 17.5h2.2"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <button type="button" class="icon-button" data-action="unordered-list" aria-label="Unordered list">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M10 7h9m-9 5h9m-9 5h9"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                />
+                <circle cx="6" cy="7" r="1.3" fill="currentColor" />
+                <circle cx="6" cy="12" r="1.3" fill="currentColor" />
+                <circle cx="6" cy="17" r="1.3" fill="currentColor" />
+              </svg>
+            </button>
+            <button type="button" class="icon-button" data-action="table" aria-label="Insert table">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <rect
+                  x="4"
+                  y="5"
+                  width="16"
+                  height="14"
+                  rx="2"
+                  ry="2"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                />
+                <path
+                  d="M4 11h16M10 5v14M14 5v14"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+            <button type="button" class="icon-button" data-action="horizontal-rule" aria-label="Insert horizontal rule">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M6 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="secondary-button mode-toggle"
+              id="editor-mode-toggle"
+              aria-pressed="false"
+              aria-label="Switch to HTML mode"
+              title="Switch to HTML mode"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M8 7l-4 5 4 5M16 7l4 5-4 5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path d="M12 5v14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+              </svg>
+              <span class="button-label">HTML</span>
+            </button>
+          </div>
+          <div class="toolbar toolbar-surface drive-actions" role="group" aria-label="Google Drive actions">
+            <button type="button" class="secondary-button" id="drive-sign-in">Sign in</button>
+            <button type="button" class="secondary-button" id="drive-sign-out" hidden>Sign out</button>
+            <button type="button" class="secondary-button" id="drive-open" disabled>Open</button>
+            <button type="button" class="primary" id="drive-save" disabled>Save</button>
+            <button type="button" class="secondary-button" id="drive-save-as" disabled>Save as</button>
+          </div>
         </div>
       </div>
     </header>

--- a/styles.css
+++ b/styles.css
@@ -58,36 +58,145 @@ header {
 header .inner {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0.75rem 1.5rem;
+  padding: 1rem 1.5rem 1.25rem;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.app-brand {
+  display: flex;
   align-items: center;
+  gap: 0.75rem;
+}
+
+.brand-mark {
+  display: inline-flex;
+  width: 2.75rem;
+  height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.9rem;
+  box-shadow: 0 12px 24px var(--shadow);
+}
+
+.brand-mark svg {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 h1 {
-  font-size: 1.1rem;
+  font-size: 1.9rem;
   margin: 0;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.toolbar-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  align-items: stretch;
 }
 
 .toolbar {
   display: flex;
-  gap: 0.25rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
   align-items: center;
 }
 
-.toolbar button, .toolbar .secondary-button {
+.toolbar-row > .toolbar-surface {
+  flex: 1 1 100%;
+}
+
+.toolbar.drive-actions {
+  gap: 0.55rem;
+}
+
+.toolbar-surface {
+  background: rgba(15, 23, 42, 0.68);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 0.6rem;
+  box-shadow: 0 14px 32px var(--surface-shadow);
+}
+
+.toolbar button,
+.toolbar .secondary-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: var(--button-bg);
   border: 1px solid transparent;
   color: var(--text);
-  padding: 0.45rem 0.6rem;
-  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.65rem;
   cursor: pointer;
   font-size: 0.85rem;
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.toolbar .icon-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+}
+
+.toolbar .icon-button svg {
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.toolbar .heading-button .toolbar-badge {
+  position: absolute;
+  bottom: 0.35rem;
+  right: 0.3rem;
+  background: var(--accent);
+  color: #0f172a;
+  border-radius: 999px;
+  padding: 0 0.35rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.toolbar .mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.85rem;
+}
+
+.toolbar .mode-toggle svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.toolbar .mode-toggle .button-label {
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.button-label {
+  font-size: 0.85rem;
+}
+
+@media (min-width: 900px) {
+  .toolbar-row {
+    flex-wrap: nowrap;
+  }
+
+  .toolbar-row > .toolbar-surface {
+    flex: 1 1 auto;
+  }
+
+  .toolbar.drive-actions {
+    justify-content: flex-end;
+  }
 }
 
 .toolbar button:hover,
@@ -262,21 +371,24 @@ main {
 .editor {
   width: 100%;
   min-height: 60vh;
-  padding: 1rem;
-  border-radius: 1rem;
-  background: var(--surface);
+  padding: 1.25rem 1.5rem;
+  border-radius: 1.1rem;
+  background: linear-gradient(170deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
   color: var(--text);
-  border: 1px solid var(--border);
+  border: 1px solid rgba(148, 163, 184, 0.45);
   font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   font-size: 1rem;
   line-height: 1.6;
-  box-shadow: 0 10px 30px var(--surface-shadow);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 24px 55px var(--strong-shadow);
+  backdrop-filter: blur(4px);
   outline: none;
   overflow-y: auto;
   white-space: pre-wrap;
   word-break: break-word;
   caret-color: var(--accent);
   cursor: text;
+  position: relative;
+  z-index: 0;
 }
 
 .editor.html-mode {
@@ -348,13 +460,26 @@ main {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: 1rem;
+  margin-top: 1.5rem;
+  padding: 0.85rem 1.25rem;
   font-size: 0.85rem;
   color: var(--text-muted);
+  background: rgba(15, 23, 42, 0.68);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.9rem;
+  box-shadow: 0 14px 32px var(--surface-shadow);
+  backdrop-filter: blur(6px);
 }
 
 .status-bar span {
-  margin-right: 1rem;
+  margin-right: 1.25rem;
+}
+
+.status-bar > div {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
 }
 
 .file-indicator {
@@ -699,6 +824,10 @@ main {
 
   .toolbar {
     justify-content: center;
+  }
+
+  .toolbar.drive-actions {
+    justify-content: flex-start;
   }
 
   .status-bar {


### PR DESCRIPTION
## Summary
- elevate the header with a new masthead treatment and grouped toolbar surfaces that separate formatting controls from Drive actions
- replace the formatting toolbar text buttons with accessible SVG icon buttons and badges for heading levels
- refresh the editor canvas and status bar styling while updating the mode toggle script so its label and accessibility metadata stay in sync

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d3b27f6c88833082c9d3ed853d9e31