### PR TITLE
Improve light mode styling and HTML editor wrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#1f2937" />
     <meta name="google-oauth-client-id" content="220212893778-a2ja5dvu9tkp700it2819hc6iajvbgiu.apps.googleusercontent.com" />
     <link rel="manifest" href="manifest.json" />
-    <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg" />
+    <link rel="icon" type="image/svg+xml" href="icons/icon-512.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
@@ -19,23 +19,7 @@
       <div class="inner">
         <div class="app-brand">
           <span class="brand-mark" aria-hidden="true">
-            <svg viewBox="0 0 32 32" role="presentation">
-              <defs>
-                <linearGradient id="brand-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                  <stop offset="0%" stop-color="#38bdf8" />
-                  <stop offset="100%" stop-color="#0ea5e9" />
-                </linearGradient>
-              </defs>
-              <rect x="2" y="2" width="28" height="28" rx="8" fill="url(#brand-gradient)" />
-              <path
-                d="M11 22.5V9.5L16 18l5-8.5v13"
-                fill="none"
-                stroke="#0f172a"
-                stroke-width="2.4"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+            <img src="icons/icon-512.svg" width="44" height="44" alt="" />
           </span>
           <h1>Mark's Markdown Editor</h1>
         </div>
@@ -78,7 +62,6 @@
                   stroke-linejoin="round"
                 />
               </svg>
-              <span class="toolbar-badge">1</span>
             </button>
             <button type="button" class="icon-button heading-button" data-action="heading-2" aria-label="Heading level 2">
               <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -98,7 +81,6 @@
                   stroke-linejoin="round"
                 />
               </svg>
-              <span class="toolbar-badge">2</span>
             </button>
             <button type="button" class="icon-button heading-button" data-action="heading-3" aria-label="Heading level 3">
               <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -118,7 +100,6 @@
                   stroke-linejoin="round"
                 />
               </svg>
-              <span class="toolbar-badge">3</span>
             </button>
             <button type="button" class="icon-button" data-action="link" aria-label="Insert link">
               <svg viewBox="0 0 24 24" aria-hidden="true">

--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,9 @@
   --shadow: rgba(15, 23, 42, 0.4);
   --surface-shadow: rgba(15, 23, 42, 0.45);
   --strong-shadow: rgba(15, 23, 42, 0.7);
+  --editor-bg: linear-gradient(170deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
+  --editor-border: rgba(148, 163, 184, 0.45);
+  --editor-shadow: 0 24px 55px var(--strong-shadow);
   --table-border: rgba(148, 163, 184, 0.2);
   --row-hover: rgba(56, 189, 248, 0.15);
   --row-selected: rgba(56, 189, 248, 0.25);
@@ -79,9 +82,10 @@ header .inner {
   justify-content: center;
   border-radius: 0.9rem;
   box-shadow: 0 12px 24px var(--shadow);
+  overflow: hidden;
 }
 
-.brand-mark svg {
+.brand-mark img {
   display: block;
   width: 100%;
   height: 100%;
@@ -117,8 +121,8 @@ h1 {
 }
 
 .toolbar-surface {
-  background: rgba(15, 23, 42, 0.68);
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 1rem;
   padding: 0.6rem;
   box-shadow: 0 14px 32px var(--surface-shadow);
@@ -149,19 +153,6 @@ h1 {
 .toolbar .icon-button svg {
   width: 1.35rem;
   height: 1.35rem;
-}
-
-.toolbar .heading-button .toolbar-badge {
-  position: absolute;
-  bottom: 0.35rem;
-  right: 0.3rem;
-  background: var(--accent);
-  color: #0f172a;
-  border-radius: 999px;
-  padding: 0 0.35rem;
-  font-size: 0.65rem;
-  font-weight: 700;
-  letter-spacing: 0.01em;
 }
 
 .toolbar .mode-toggle {
@@ -373,13 +364,13 @@ main {
   min-height: 60vh;
   padding: 1.25rem 1.5rem;
   border-radius: 1.1rem;
-  background: linear-gradient(170deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
+  background: var(--editor-bg);
   color: var(--text);
-  border: 1px solid rgba(148, 163, 184, 0.45);
+  border: 1px solid var(--editor-border);
   font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   font-size: 1rem;
   line-height: 1.6;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 24px 55px var(--strong-shadow);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), var(--editor-shadow);
   backdrop-filter: blur(4px);
   outline: none;
   overflow-y: auto;
@@ -393,9 +384,10 @@ main {
 
 .editor.html-mode {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  white-space: pre;
-  word-break: normal;
-  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  overflow-x: hidden;
   tab-size: 2;
 }
 
@@ -464,8 +456,8 @@ main {
   padding: 0.85rem 1.25rem;
   font-size: 0.85rem;
   color: var(--text-muted);
-  background: rgba(15, 23, 42, 0.68);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 0.9rem;
   box-shadow: 0 14px 32px var(--surface-shadow);
   backdrop-filter: blur(6px);
@@ -784,7 +776,7 @@ main {
   :root {
     --bg-gradient-start: #f8fafc;
     --bg-gradient-end: #e2e8f0;
-    --surface: rgba(255, 255, 255, 0.92);
+    --surface: #ffffff;
     --surface-strong: #ffffff;
     --header-bg: rgba(248, 250, 252, 0.85);
     --input-bg: rgba(255, 255, 255, 0.95);
@@ -792,13 +784,16 @@ main {
     --text-muted: rgba(15, 23, 42, 0.6);
     --text-subtle: rgba(15, 23, 42, 0.7);
     --border: rgba(15, 23, 42, 0.12);
-    --button-bg: rgba(148, 163, 184, 0.15);
-    --button-bg-hover: rgba(148, 163, 184, 0.25);
-    --button-border-hover: rgba(148, 163, 184, 0.4);
+    --button-bg: #f8fafc;
+    --button-bg-hover: #e2e8f0;
+    --button-border-hover: rgba(148, 163, 184, 0.35);
     --overlay: rgba(15, 23, 42, 0.3);
     --shadow: rgba(15, 23, 42, 0.08);
     --surface-shadow: rgba(15, 23, 42, 0.1);
     --strong-shadow: rgba(15, 23, 42, 0.12);
+    --editor-bg: #ffffff;
+    --editor-border: rgba(15, 23, 42, 0.12);
+    --editor-shadow: 0 18px 44px rgba(15, 23, 42, 0.1);
     --table-border: rgba(15, 23, 42, 0.08);
     --row-hover: rgba(56, 189, 248, 0.12);
     --row-selected: rgba(56, 189, 248, 0.18);


### PR DESCRIPTION
## Summary
- replace the toolbar logo with the existing 512px SVG favicon and remove unused heading number badges
- switch surface and editor styling to use CSS variables so light mode surfaces and buttons render on white backgrounds
- enable word wrapping for the HTML editor view while preserving monospace formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3c7081a508330ac9decc408315a24