### PR TITLE
Revamp bold and heading icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,11 @@
           <div class="toolbar toolbar-surface formatting" role="toolbar" aria-label="Markdown formatting">
             <button type="button" class="icon-button" data-action="bold" aria-label="Bold">
               <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M7 4.75h1.75v14.5H7z" fill="currentColor" />
-                <path d="M8.75 4.75H13a3.25 3.25 0 110 6.5H8.75z" fill="currentColor" />
-                <path d="M8.75 11.25H13.5a3.25 3.25 0 110 6.5H8.75z" fill="currentColor" />
+                <path
+                  d="M8.5 4.5H13c3 0 5.3 1.9 5.3 4.6 0 1.9-1.1 3.4-2.8 4 1.9.6 3.2 2.1 3.2 4.2 0 2.9-2.3 4.9-5.5 4.9H8.5Zm1.7 1.7h2.6a2.3 2.3 0 010 4.6h-2.6Zm0 6.1h3a2.45 2.45 0 010 4.9h-3Z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
               </svg>
             </button>
             <button type="button" class="icon-button" data-action="italic" aria-label="Italic">
@@ -53,14 +55,23 @@
                   stroke-width="1.7"
                   stroke-linecap="round"
                 />
-                <path
-                  d="M17.5 9l2-1.2v9.7"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.7"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
+                <g transform="translate(14 6)">
+                  <path
+                    d="M5.6 1.2 7.4 0v12"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.7"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M1.4 12h6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.7"
+                    stroke-linecap="round"
+                  />
+                </g>
               </svg>
             </button>
             <button type="button" class="icon-button heading-button" data-action="heading-2" aria-label="Heading level 2">
@@ -72,14 +83,23 @@
                   stroke-width="1.7"
                   stroke-linecap="round"
                 />
-                <path
-                  d="M16 10.2a2.6 2.6 0 012.6-2.7c1.4 0 2.4.9 2.4 2.1 0 1-.6 1.6-1.5 2.4l-2.6 2.2h4.1"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
+                <g transform="translate(14 6)">
+                  <path
+                    d="M1.4 3.3L3.4 1.1Q4.6 0 6.7 0Q9.7 0 9.7 2.5Q9.7 4 8.2 5.1L2.7 9.8H9.4"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.7"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <path
+                    d="M2 12H8.9"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.7"
+                    stroke-linecap="round"
+                  />
+                </g>
               </svg>
             </button>
             <button type="button" class="icon-button heading-button" data-action="heading-3" aria-label="Heading level 3">
@@ -91,14 +111,16 @@
                   stroke-width="1.7"
                   stroke-linecap="round"
                 />
-                <path
-                  d="M16.5 10a2.4 2.4 0 012.4-2.5c1.2 0 2.1.8 2.1 1.9 0 .9-.5 1.5-1.3 1.8 1 .3 1.6 1.1 1.6 2.1 0 1.4-1.1 2.4-2.6 2.4-1.1 0-2-.6-2.5-1.5"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
+                <g transform="translate(14 6)">
+                  <path
+                    d="M1.5 2.5Q2.4 0.6 5.5 0Q8.6 0.6 8.6 2.5Q8.6 3.9 7.1 4.6Q8.8 5.3 8.8 7Q8.8 9.4 6.6 10.7Q4.8 11.8 2.8 11.2Q1.6 10.8 1 9.9"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.7"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </g>
               </svg>
             </button>
             <button type="button" class="icon-button" data-action="link" aria-label="Insert link">


### PR DESCRIPTION
## Summary
- redesign the bold toolbar SVG into a single even-odd filled shape for a cleaner look
- rework heading number drawings using a shared coordinate system so 1, 2, and 3 render at the same size

## Testing
- npm test *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c893b8ec833084c90390549fae69