### PR TITLE
Fix heading toolbar icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,13 +39,13 @@
               <i class="fa-solid fa-italic" aria-hidden="true"></i>
             </button>
             <button type="button" class="icon-button heading-button" data-action="heading-1" aria-label="Heading level 1">
-              <i class="fa-solid fa-h1" aria-hidden="true"></i>
+              <span class="heading-icon" aria-hidden="true">H1</span>
             </button>
             <button type="button" class="icon-button heading-button" data-action="heading-2" aria-label="Heading level 2">
-              <i class="fa-solid fa-h2" aria-hidden="true"></i>
+              <span class="heading-icon" aria-hidden="true">H2</span>
             </button>
             <button type="button" class="icon-button heading-button" data-action="heading-3" aria-label="Heading level 3">
-              <i class="fa-solid fa-h3" aria-hidden="true"></i>
+              <span class="heading-icon" aria-hidden="true">H3</span>
             </button>
             <button type="button" class="icon-button" data-action="link" aria-label="Insert link">
               <i class="fa-solid fa-link" aria-hidden="true"></i>

--- a/styles.css
+++ b/styles.css
@@ -163,6 +163,18 @@ h1 {
   line-height: 1;
 }
 
+.toolbar .icon-button.heading-button > .heading-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.35rem;
+  height: 1.35rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
 .toolbar .mode-toggle {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- replace unavailable Font Awesome heading icons with semantic text labels
- add styling for the new heading icons so they match other toolbar controls

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3d6162e3c8330aecc50db787fa93c