### PR TITLE
Adjust line break spacing in editor

### DIFF
--- a/app.js
+++ b/app.js
@@ -476,6 +476,7 @@ function renderFormattedMarkdown(content) {
     }
 
     if (!line) {
+      lineElement.classList.add('is-empty');
       lineElement.innerHTML = '&#8203;';
     } else {
       lineElement.textContent = '';
@@ -485,7 +486,11 @@ function renderFormattedMarkdown(content) {
     fragment.appendChild(lineElement);
 
     if (index < lines.length - 1) {
-      fragment.appendChild(document.createTextNode('\n'));
+      const lineBreak = document.createElement('span');
+      lineBreak.classList.add('editor-line-break');
+      lineBreak.setAttribute('aria-hidden', 'true');
+      lineBreak.textContent = '\n';
+      fragment.appendChild(lineBreak);
     }
   });
 

--- a/styles.css
+++ b/styles.css
@@ -434,6 +434,19 @@ main {
   scroll-margin-top: var(--header-offset);
 }
 
+.editor-line.is-empty {
+  min-height: 1rem;
+}
+
+.editor-line-break {
+  display: block;
+  height: 0.35rem;
+  line-height: 0;
+  font-size: 0;
+  pointer-events: none;
+  user-select: none;
+}
+
 .editor-line.heading-1 {
   font-size: 1.75rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- tighten rendered Markdown spacing by classifying empty lines and rendering dedicated break markers
- style the new line break markers so single line breaks appear closer together while preserving paragraph spacing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3d7a4e4488330821fb05871ed6116