### PR TITLE
Add undo/redo controls with persistent history

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,26 @@
         </div>
         <div class="toolbar-row">
           <div class="toolbar toolbar-surface formatting" role="toolbar" aria-label="Markdown formatting">
+            <button
+              type="button"
+              class="icon-button"
+              data-action="undo"
+              aria-label="Undo"
+              title="Undo"
+              disabled
+            >
+              <i class="fa-solid fa-rotate-left" aria-hidden="true"></i>
+            </button>
+            <button
+              type="button"
+              class="icon-button"
+              data-action="redo"
+              aria-label="Redo"
+              title="Redo"
+              disabled
+            >
+              <i class="fa-solid fa-rotate-right" aria-hidden="true"></i>
+            </button>
             <button type="button" class="icon-button" data-action="bold" aria-label="Bold">
               <i class="fa-solid fa-bold" aria-hidden="true"></i>
             </button>


### PR DESCRIPTION
## Summary
- add undo and redo buttons with Font Awesome icons to the formatting toolbar
- implement a bounded history stack that records editor content after each change
- wire undo/redo keyboard shortcuts and reset history when files are loaded

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3dad5bbe88330ac6f5d794f3731b7