### PR TITLE
Restyle Google Drive save buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,11 +98,36 @@
             </button>
           </div>
           <div class="toolbar toolbar-surface drive-actions" role="group" aria-label="Google Drive actions">
-            <button type="button" class="secondary-button" id="drive-sign-in">Sign in</button>
-            <button type="button" class="secondary-button" id="drive-sign-out" hidden>Sign out</button>
-            <button type="button" class="secondary-button" id="drive-open" disabled>Open</button>
-            <button type="button" class="primary" id="drive-save" disabled>Save</button>
-            <button type="button" class="secondary-button" id="drive-save-as" disabled>Save as</button>
+            <button type="button" class="secondary-button drive-button" id="drive-sign-in">
+              <span class="drive-icon" aria-hidden="true">
+                <i class="fa-brands fa-google-drive"></i>
+              </span>
+              <span class="button-label">Sign in</span>
+            </button>
+            <button type="button" class="secondary-button drive-button" id="drive-sign-out" hidden>
+              <span class="drive-icon" aria-hidden="true">
+                <i class="fa-brands fa-google-drive"></i>
+              </span>
+              <span class="button-label">Sign out</span>
+            </button>
+            <button type="button" class="secondary-button drive-button" id="drive-open" disabled>
+              <span class="drive-icon" aria-hidden="true">
+                <i class="fa-solid fa-folder-open"></i>
+              </span>
+              <span class="button-label">Open</span>
+            </button>
+            <button type="button" class="primary drive-button" id="drive-save" disabled>
+              <span class="drive-icon" aria-hidden="true">
+                <i class="fa-solid fa-cloud-arrow-up"></i>
+              </span>
+              <span class="button-label">Save</span>
+            </button>
+            <button type="button" class="secondary-button drive-button" id="drive-save-as" disabled>
+              <span class="drive-icon" aria-hidden="true">
+                <i class="fa-solid fa-file-export"></i>
+              </span>
+              <span class="button-label">Save as</span>
+            </button>
           </div>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,60 @@ h1 {
   gap: 0.55rem;
 }
 
+.toolbar.drive-actions .drive-button {
+  gap: 0.45rem;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toolbar.drive-actions .drive-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.7rem;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--accent);
+  font-size: 0.95rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 6px 14px rgba(15, 23, 42, 0.35);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toolbar.drive-actions .drive-button:hover .drive-icon {
+  background: rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 10px 18px rgba(15, 23, 42, 0.4);
+}
+
+.toolbar.drive-actions .drive-button.primary {
+  box-shadow: 0 18px 32px rgba(56, 189, 248, 0.35);
+}
+
+.toolbar.drive-actions .drive-button.primary .drive-icon {
+  background: rgba(255, 255, 255, 0.82);
+  color: #0f172a;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 12px 25px rgba(15, 23, 42, 0.25);
+}
+
+.toolbar.drive-actions .drive-button.primary:hover {
+  box-shadow: 0 22px 38px rgba(56, 189, 248, 0.42);
+}
+
+.toolbar.drive-actions .drive-button.primary:hover .drive-icon {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.toolbar.drive-actions .drive-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.toolbar.drive-actions .drive-button:disabled .drive-icon {
+  opacity: 0.8;
+}
+
 .toolbar-surface {
   background: var(--surface);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- add Google Drive and file action icons to the Drive toolbar buttons
- introduce refreshed styling for the Drive action buttons to better match the app chrome

## Testing
- Manual validation via `python -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68d3e45978388330b80776214472dd41