### PR TITLE
Center toolbars and expand drive actions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -100,7 +100,7 @@ h1 {
 
 .toolbar-row {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 0.9rem;
   align-items: stretch;
 }
@@ -113,7 +113,13 @@ h1 {
 }
 
 .toolbar-row > .toolbar-surface {
-  flex: 1 1 100%;
+  flex: 0 0 100%;
+  width: 100%;
+}
+
+.toolbar.formatting,
+.toolbar.drive-actions {
+  justify-content: center;
 }
 
 .toolbar.drive-actions {
@@ -256,20 +262,6 @@ h1 {
 
 .button-label {
   font-size: 0.85rem;
-}
-
-@media (min-width: 900px) {
-  .toolbar-row {
-    flex-wrap: nowrap;
-  }
-
-  .toolbar-row > .toolbar-surface {
-    flex: 1 1 auto;
-  }
-
-  .toolbar.drive-actions {
-    justify-content: flex-end;
-  }
 }
 
 .toolbar button:hover,


### PR DESCRIPTION
## Summary
- ensure the formatting and Google Drive toolbar surfaces each occupy the full row width
- center the contents of both toolbar surfaces for a consistent layout
- keep the stacked toolbar layout on wide viewports by removing the desktop row override

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3e63765f88330b317dc873a8c2036