### PR TITLE
Add privacy policy and terms of service pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,19 @@ Google requires that you supply your own OAuth client ID (and optionally an API 
 ```
 .
 ├── index.html          # Main application markup
+├── privacy.html        # Privacy Policy for the web app
 ├── styles.css          # Layout and visual styling
 ├── app.js              # Editor logic and Google Drive integration
 ├── manifest.json       # PWA manifest
 ├── service-worker.js   # Offline caching
+├── terms.html          # Terms of Service for the web app
 └── icons/              # PWA icons
 ```
+
+## Policies
+
+- [Privacy Policy](privacy.html)
+- [Terms of Service](terms.html)
 
 ## Development notes
 

--- a/index.html
+++ b/index.html
@@ -181,6 +181,16 @@
       </div>
     </main>
 
+    <footer class="site-footer">
+      <div class="inner">
+        <p>© 2024 Mark's Markdown Editor.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="privacy.html">Privacy Policy</a>
+          <a href="terms.html">Terms of Service</a>
+        </nav>
+      </div>
+    </footer>
+
     <div id="drive-dialog" role="dialog" aria-modal="true" aria-labelledby="drive-dialog-title">
       <div class="dialog-content">
         <div class="dialog-header">

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Privacy Policy · Mark's Markdown Editor</title>
+    <meta
+      name="description"
+      content="Privacy practices for Mark's Markdown Editor, including details about Google Drive access, local storage, and how your information is used."
+    />
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" type="image/svg+xml" href="icons/icon-512.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="legal-page">
+    <header class="legal-header">
+      <div class="inner">
+        <div class="legal-header-bar">
+          <a class="brand-link" href="index.html">
+            <span class="brand-mark" aria-hidden="true">
+              <img src="icons/icon-512.svg" width="44" height="44" alt="" />
+            </span>
+            <span class="brand-name">
+              Mark's Markdown Editor
+              <span>Write, sync, and manage Markdown anywhere.</span>
+            </span>
+          </a>
+          <nav class="legal-header-links" aria-label="Legal pages">
+            <a href="privacy.html" aria-current="page">Privacy Policy</a>
+            <a href="terms.html">Terms of Service</a>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main class="legal-main">
+      <article class="legal-content">
+        <header>
+          <p class="legal-meta">Effective date: 15 March 2024</p>
+          <h1>Privacy Policy</h1>
+          <p>
+            Mark's Markdown Editor (the "Service") helps you compose Markdown documents locally and optionally sync them to
+            your Google Drive. This Privacy Policy explains what information we access, how we handle it, and the choices you
+            have.
+          </p>
+        </header>
+
+        <section>
+          <h2>Information We Access</h2>
+          <p>
+            We design the Service so that most of your work stays on your device. Depending on how you use the Service, we may
+            access the following limited information:
+          </p>
+          <ul>
+            <li>
+              <strong>Google Account profile data</strong> — When you sign in with Google, we receive your basic profile
+              information (name, email address, and profile image) directly from Google to personalize the experience.
+            </li>
+            <li>
+              <strong>Google Drive file data</strong> — If you choose to open or save documents via Google Drive, we read and
+              write the Markdown or plain text files you select.
+            </li>
+            <li>
+              <strong>Local application state</strong> — We store settings, cached file metadata, and offline drafts in your
+              browser's local storage so the editor works even without a network connection.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Google Authentication &amp; Drive Access</h2>
+          <p>
+            The Service uses Google Identity Services to authenticate you and Google's Drive API to read and write the files you
+            explicitly select. We request the minimum OAuth scopes required to list, open, and save Markdown files. We never
+            access other Google data, nor do we store your Google credentials on our servers.
+          </p>
+          <p class="legal-callout">
+            You can revoke the Service's Drive access at any time from your
+            <a href="https://myaccount.google.com/permissions" target="_blank" rel="noopener">Google account permissions</a>
+            page.
+          </p>
+        </section>
+
+        <section>
+          <h2>How We Use Information</h2>
+          <p>
+            Information is used solely to deliver the features you request:
+          </p>
+          <ul>
+            <li>Authenticating you with Google and maintaining your session while you are signed in.</li>
+            <li>Listing your Google Drive files and saving updates to the files you select.</li>
+            <li>Remembering interface preferences, such as editor mode and recently used file names.</li>
+            <li>Providing offline access to drafts until you choose to delete them.</li>
+          </ul>
+          <p>We do not sell or rent your information and we do not use it for advertising.</p>
+        </section>
+
+        <section>
+          <h2>Local Storage &amp; Offline Data</h2>
+          <p>
+            Drafts and configuration data stored locally remain on your device. You can clear this information by signing out,
+            clearing your browser data, or using the "Reset" controls made available in the application settings.
+          </p>
+        </section>
+
+        <section>
+          <h2>Data Sharing &amp; Third Parties</h2>
+          <p>
+            We only share your information as necessary to provide the Service:
+          </p>
+          <ul>
+            <li>Google Identity Services and Google Drive APIs process your authentication and file requests.</li>
+            <li>Service workers and browser APIs store limited data on your device for offline functionality.</li>
+          </ul>
+          <p>We do not transfer your information to other third parties without your consent unless required by law.</p>
+        </section>
+
+        <section>
+          <h2>Data Retention &amp; Security</h2>
+          <p>
+            We retain Google Drive access tokens only for the duration of your session and rely on Google's infrastructure for
+            secure authentication. Locally cached drafts stay on your device until you remove them. We regularly review scopes
+            and permissions to ensure we request only what is necessary for the editor to function.
+          </p>
+        </section>
+
+        <section>
+          <h2>Your Choices &amp; Rights</h2>
+          <p>You can control your data in several ways:</p>
+          <ul>
+            <li>Use the editor offline without signing in to avoid sharing any Google information.</li>
+            <li>Disconnect the Service from your Google account using Google's security settings.</li>
+            <li>Delete local drafts and cached data through your browser or the application's reset controls.</li>
+            <li>Contact us to request access to or deletion of any information stored on our systems.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Children's Privacy</h2>
+          <p>
+            The Service is not intended for children under 13. If we learn that we have inadvertently accessed information from a
+            child under 13, we will promptly revoke access and delete the data.
+          </p>
+        </section>
+
+        <section>
+          <h2>Changes to This Policy</h2>
+          <p>
+            We may update this Privacy Policy to reflect new functionality or legal requirements. Material changes will be
+            highlighted within the application and the "Effective date" above will be updated.
+          </p>
+        </section>
+
+        <section>
+          <h2>Contact Us</h2>
+          <p class="legal-contact">
+            If you have questions about this Privacy Policy, contact us at
+            <a href="mailto:privacy@marksmarkdowneditor.app">privacy@marksmarkdowneditor.app</a>.
+          </p>
+        </section>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="inner">
+        <p>© 2024 Mark's Markdown Editor.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="privacy.html" aria-current="page">Privacy Policy</a>
+          <a href="terms.html">Terms of Service</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -798,6 +798,252 @@ main {
   align-items: center;
 }
 
+/* Footer */
+
+.site-footer {
+  margin-top: auto;
+  background: var(--surface-strong);
+  border-top: 1px solid var(--border);
+  box-shadow: 0 -8px 24px var(--shadow);
+}
+
+.site-footer .inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+  text-align: center;
+}
+
+.site-footer p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.footer-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.footer-nav a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.footer-nav a:hover,
+.footer-nav a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (min-width: 768px) {
+  .site-footer .inner {
+    flex-direction: row;
+    justify-content: space-between;
+    text-align: left;
+  }
+}
+
+/* Legal pages */
+
+body.legal-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header.legal-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 4px 12px var(--shadow);
+}
+
+header.legal-header .inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.1rem 1.75rem;
+}
+
+.legal-header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.legal-header-bar .brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: var(--text);
+  font-weight: 600;
+  font-size: 1.2rem;
+  letter-spacing: 0.02em;
+}
+
+.legal-header-bar .brand-link:hover,
+.legal-header-bar .brand-link:focus-visible {
+  color: var(--accent);
+}
+
+.legal-header-bar .brand-link .brand-name {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.legal-header-bar .brand-link .brand-name span {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.legal-header-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.legal-header-links a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 0.25rem 0;
+}
+
+.legal-header-links a:hover,
+.legal-header-links a:focus-visible {
+  text-decoration: underline;
+}
+
+.legal-header-links a[aria-current='page'] {
+  color: #ffffff;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 6px;
+}
+
+.legal-main {
+  flex: 1;
+  width: 100%;
+  padding: 2.5rem 1.25rem 4rem;
+  display: flex;
+  justify-content: center;
+}
+
+.legal-content {
+  width: min(100%, 900px);
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 2.5rem;
+  box-shadow: 0 22px 48px var(--surface-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.legal-content h1 {
+  margin: 0;
+  font-size: 2.15rem;
+  letter-spacing: 0.02em;
+}
+
+.legal-content h2 {
+  margin: 2rem 0 0.75rem;
+  font-size: 1.4rem;
+}
+
+.legal-content p {
+  margin: 0;
+  color: var(--text-subtle);
+  line-height: 1.7;
+}
+
+.legal-content section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.legal-content ul,
+.legal-content ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--text-subtle);
+}
+
+.legal-content li {
+  margin: 0;
+}
+
+.legal-content strong {
+  color: #ffffff;
+}
+
+.legal-meta {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.legal-callout {
+  border-left: 3px solid var(--accent);
+  padding-left: 1rem;
+  color: var(--text-subtle);
+}
+
+.legal-contact {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.legal-contact a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.legal-contact a:hover,
+.legal-contact a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  header.legal-header .inner {
+    padding: 1rem 1.25rem;
+  }
+
+  .legal-content {
+    padding: 1.75rem;
+  }
+
+  .legal-content h1 {
+    font-size: 1.85rem;
+  }
+
+  .legal-content h2 {
+    font-size: 1.25rem;
+  }
+}
+
 .drive-save-controls input {
   flex: 1;
 }

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Terms of Service · Mark's Markdown Editor</title>
+    <meta
+      name="description"
+      content="Terms governing the use of Mark's Markdown Editor, including eligibility requirements, acceptable use, and Google Drive integration."
+    />
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" type="image/svg+xml" href="icons/icon-512.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="legal-page">
+    <header class="legal-header">
+      <div class="inner">
+        <div class="legal-header-bar">
+          <a class="brand-link" href="index.html">
+            <span class="brand-mark" aria-hidden="true">
+              <img src="icons/icon-512.svg" width="44" height="44" alt="" />
+            </span>
+            <span class="brand-name">
+              Mark's Markdown Editor
+              <span>Write, sync, and manage Markdown anywhere.</span>
+            </span>
+          </a>
+          <nav class="legal-header-links" aria-label="Legal pages">
+            <a href="privacy.html">Privacy Policy</a>
+            <a href="terms.html" aria-current="page">Terms of Service</a>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <main class="legal-main">
+      <article class="legal-content">
+        <header>
+          <p class="legal-meta">Effective date: 15 March 2024</p>
+          <h1>Terms of Service</h1>
+          <p>
+            These Terms of Service ("Terms") govern your use of Mark's Markdown Editor (the "Service"). By accessing or using the
+            Service you agree to be bound by these Terms. If you do not agree, do not use the Service.
+          </p>
+        </header>
+
+        <section>
+          <h2>1. Eligibility &amp; Account Responsibilities</h2>
+          <p>
+            You must be at least 13 years old to use the Service. Some features require signing in with your Google account. You
+            are responsible for maintaining the confidentiality of your Google credentials and for all activity that occurs under
+            your account when connected to the Service.
+          </p>
+        </section>
+
+        <section>
+          <h2>2. Google Drive Integration</h2>
+          <p>
+            When you choose to connect your Google account, the Service requests the minimal Google Drive scopes required to list,
+            open, create, and update Markdown or plain text files you select. You grant us permission to access only those files
+            and metadata necessary to fulfill your explicit requests. You may revoke access at any time through your Google
+            security settings.
+          </p>
+          <p>
+            You are solely responsible for ensuring that you have the right to upload, edit, and distribute any content stored in
+            Google Drive. We are not liable for loss of data arising from Google Drive outages or your decision to revoke access.
+          </p>
+        </section>
+
+        <section>
+          <h2>3. Your Content &amp; License</h2>
+          <p>
+            You retain ownership of all content you create or import into the Service. By using the Google Drive integration you
+            grant us a limited license to process your content for the sole purpose of providing the Service's editing and syncing
+            capabilities. We do not claim ownership of your files and we do not publish them.
+          </p>
+        </section>
+
+        <section>
+          <h2>4. Acceptable Use</h2>
+          <p>When using the Service you agree not to:</p>
+          <ul>
+            <li>Violate any applicable law, regulation, or third-party rights.</li>
+            <li>Upload malicious code, automate scraping, or otherwise interfere with the Service's operation.</li>
+            <li>Attempt to gain unauthorized access to any systems or accounts related to the Service.</li>
+            <li>Use the Service to store or transmit personal data of others without proper consent.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>5. Local Storage &amp; Offline Use</h2>
+          <p>
+            The Service stores drafts and settings in your browser to support offline editing. You are responsible for managing
+            and backing up any local data. Clearing your browser storage may permanently remove drafts stored locally.
+          </p>
+        </section>
+
+        <section>
+          <h2>6. Service Availability &amp; Modifications</h2>
+          <p>
+            We strive to keep the Service available, but it may be interrupted, suspended, or modified at any time without notice.
+            We may update the Service to improve performance or address security concerns. Continued use after an update
+            constitutes acceptance of the modified Service.
+          </p>
+        </section>
+
+        <section>
+          <h2>7. Feedback</h2>
+          <p>
+            If you provide suggestions or feedback, you grant us a non-exclusive, royalty-free license to use that feedback to
+            improve the Service without any obligation to you.
+          </p>
+        </section>
+
+        <section>
+          <h2>8. Disclaimers</h2>
+          <p>
+            The Service is provided on an "as is" and "as available" basis. To the fullest extent permitted by law, we disclaim
+            all warranties, express or implied, including warranties of merchantability, fitness for a particular purpose, and
+            non-infringement. We do not guarantee that the Service will be uninterrupted, secure, or error-free.
+          </p>
+        </section>
+
+        <section>
+          <h2>9. Limitation of Liability</h2>
+          <p>
+            To the maximum extent permitted by law, we are not liable for any indirect, incidental, special, consequential, or
+            punitive damages, or for loss of profits, data, or goodwill arising from your use of the Service. Our total liability
+            for any claim under these Terms is limited to the greater of twenty dollars (USD $20) or the amount you paid to use
+            the Service in the 12 months preceding the claim (if any).
+          </p>
+        </section>
+
+        <section>
+          <h2>10. Indemnification</h2>
+          <p>
+            You agree to indemnify and hold harmless the Service's maintainers from any claims, damages, liabilities, and expenses
+            (including reasonable legal fees) arising from your content or your violation of these Terms.
+          </p>
+        </section>
+
+        <section>
+          <h2>11. Termination</h2>
+          <p>
+            You may stop using the Service at any time. We may suspend or terminate your access if we believe you have violated
+            these Terms or if continued access poses a risk to the Service or other users. Upon termination, sections 3, 8, 9, and
+            10 will continue to apply.
+          </p>
+        </section>
+
+        <section>
+          <h2>12. Changes to These Terms</h2>
+          <p>
+            We may update these Terms occasionally. When we do, we will revise the "Effective date" above and, if the changes are
+            material, provide notice within the Service. Continued use after the effective date of updated Terms constitutes your
+            acceptance of the changes.
+          </p>
+        </section>
+
+        <section>
+          <h2>13. Governing Law</h2>
+          <p>
+            These Terms are governed by and construed in accordance with the laws of the jurisdiction in which the Service's
+            primary maintainers reside, without regard to its conflict of law principles.
+          </p>
+        </section>
+
+        <section>
+          <h2>14. Contact Us</h2>
+          <p class="legal-contact">
+            Questions about these Terms? Email us at
+            <a href="mailto:legal@marksmarkdowneditor.app">legal@marksmarkdowneditor.app</a>.
+          </p>
+        </section>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="inner">
+        <p>© 2024 Mark's Markdown Editor.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="privacy.html">Privacy Policy</a>
+          <a href="terms.html" aria-current="page">Terms of Service</a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated privacy policy and terms of service pages with legal content for the editor
- introduce shared footer navigation linking to the new policies and style support for legal layouts
- document the new pages in the README for discoverability

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3f0035d648330b13d9d7e25eac3d0