### PR TITLE
Adjust legal page emphasis and spacing

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -41,7 +41,7 @@
         <header>
           <p class="legal-meta">Effective date: 24 September 2025</p>
           <h1>Privacy Policy</h1>
-          <p>
+          <p class="legal-intro">
             Mark's Markdown Editor (the "Service") helps you compose Markdown documents locally and optionally sync them to
             your Google Drive. This Privacy Policy explains what information we access, how we handle it, and the choices you
             have.

--- a/styles.css
+++ b/styles.css
@@ -995,7 +995,13 @@ header.legal-header .inner {
 }
 
 .legal-content strong {
-  color: #ffffff;
+  color: var(--accent);
+}
+
+.legal-content .legal-intro {
+  padding: 1.25rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.6);
 }
 
 .legal-meta {

--- a/terms.html
+++ b/terms.html
@@ -41,7 +41,7 @@
         <header>
           <p class="legal-meta">Effective date: 24 September 2025</p>
           <h1>Terms of Service</h1>
-          <p>
+          <p class="legal-intro">
             These Terms of Service ("Terms") govern your use of Mark's Markdown Editor (the "Service"). By accessing or using the
             Service you agree to be bound by these Terms. If you do not agree, do not use the Service.
           </p>


### PR DESCRIPTION
## Summary
- highlight legal page strong emphasis text with the accent color for better contrast
- add padded introductory paragraphs to the privacy policy and terms pages for improved readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f36eaba4833095e1489cb756d602