### PR TITLE
Remove sticky behavior from legal content headers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -959,8 +959,19 @@ header.legal-header .inner {
   gap: 1.5rem;
 }
 
+.legal-content > header {
+  position: static;
+  top: auto;
+  z-index: auto;
+  backdrop-filter: none;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+}
+
 .legal-content h1 {
-  margin: 0;
+  margin: 0 0 1rem;
+  padding-bottom: 0.35rem;
   font-size: 2.15rem;
   letter-spacing: 0.02em;
 }


### PR DESCRIPTION
## Summary
- override the legal article header styling so it no longer inherits the global sticky header treatment
- allow the Privacy Policy and Terms pages to scroll naturally without the intro block pinning to the viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f73d65288330b78e76453a4f4c94