### PR TITLE
Pin table of contents beside editor

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -577,9 +577,10 @@ main {
   .toc {
     display: block;
     position: sticky;
-    top: 6.5rem;
-    max-height: calc(100vh - 7rem);
+    top: calc(var(--header-offset) + 1.5rem);
+    max-height: calc(100vh - var(--header-offset) - 2.5rem);
     overflow: auto;
+    align-self: start;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the table of contents visible on large displays by anchoring it to the header height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3f90172108330a55acaeab77e18fa