### PR TITLE
Fade Google sign out button when signed out

### DIFF
--- a/app.js
+++ b/app.js
@@ -1758,7 +1758,9 @@ function updateDriveButtons(isSignedIn) {
     editorElements.driveRefreshButton.disabled = disabled;
   }
   editorElements.driveSignInButton.hidden = isSignedIn;
-  editorElements.driveSignOutButton.hidden = !isSignedIn;
+  editorElements.driveSignOutButton.hidden = false;
+  editorElements.driveSignOutButton.disabled = disabled;
+  editorElements.driveSignOutButton.setAttribute('aria-disabled', disabled ? 'true' : 'false');
   if (!isSignedIn && !isDriveConfigured()) {
     editorElements.driveStatus.textContent = 'Google Drive credentials not configured';
   } else {

--- a/index.html
+++ b/index.html
@@ -104,7 +104,13 @@
               </span>
               <span class="button-label">Sign in</span>
             </button>
-            <button type="button" class="secondary-button drive-button" id="drive-sign-out" hidden>
+            <button
+              type="button"
+              class="secondary-button drive-button"
+              id="drive-sign-out"
+              disabled
+              aria-disabled="true"
+            >
               <span class="drive-icon" aria-hidden="true">
                 <i class="fa-brands fa-google-drive"></i>
               </span>


### PR DESCRIPTION
## Summary
- keep the Google Drive sign-out button visible and disabled while signed out so it fades like the other Drive actions
- expose the button in the markup with an initial disabled state and keep its aria-disabled attribute in sync

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3fa79548483308e01ab1790936e12