### PR TITLE
Improve editor keyboard handling and persistence

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,10 +1,15 @@
-const CACHE_NAME = 'markdown-editor-cache-v2';
+const CACHE_NAME = 'markdown-editor-cache-v3';
 const OFFLINE_ASSETS = [
   './',
   './index.html',
   './styles.css',
   './app.js',
   './manifest.json',
+  './privacy.html',
+  './terms.html',
+  './vendor/marked.min.js',
+  './vendor/turndown.min.js',
+  './vendor/turndown-plugin-gfm.min.js',
   './icons/icon-192.svg',
   './icons/icon-512.svg'
 ];


### PR DESCRIPTION
## Summary
- cache vendor libraries and legal documents in the service worker so the app shell works offline
- hide the Google Drive sign-out control when logged out and improve keyboard handling (Tab/Shift+Tab indentation and Delete at line ends)
- throttle editor persistence with idle-aware storage writes, batch undo history during typing, and flush pending writes on saves/unload

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3ffe66b908330b2f94c08d0b97cef