### PR TITLE
Add extra formatting controls and dynamic document title

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,12 @@
             <button type="button" class="icon-button" data-action="italic" aria-label="Italic">
               <i class="fa-solid fa-italic" aria-hidden="true"></i>
             </button>
+            <button type="button" class="icon-button" data-action="strikethrough" aria-label="Strikethrough">
+              <i class="fa-solid fa-strikethrough" aria-hidden="true"></i>
+            </button>
+            <button type="button" class="icon-button" data-action="inline-code" aria-label="Inline code">
+              <i class="fa-solid fa-code" aria-hidden="true"></i>
+            </button>
             <button type="button" class="icon-button heading-button" data-action="heading-1" aria-label="Heading level 1">
               <span class="heading-icon" aria-hidden="true">H1</span>
             </button>
@@ -66,6 +72,9 @@
             </button>
             <button type="button" class="icon-button heading-button" data-action="heading-3" aria-label="Heading level 3">
               <span class="heading-icon" aria-hidden="true">H3</span>
+            </button>
+            <button type="button" class="icon-button" data-action="blockquote" aria-label="Block quote">
+              <i class="fa-solid fa-quote-right" aria-hidden="true"></i>
             </button>
             <button type="button" class="icon-button" data-action="link" aria-label="Insert link">
               <i class="fa-solid fa-link" aria-hidden="true"></i>
@@ -81,6 +90,9 @@
             </button>
             <button type="button" class="icon-button" data-action="table" aria-label="Insert table">
               <i class="fa-solid fa-table" aria-hidden="true"></i>
+            </button>
+            <button type="button" class="icon-button" data-action="code-block" aria-label="Insert code block">
+              <i class="fa-solid fa-file-code" aria-hidden="true"></i>
             </button>
             <button type="button" class="icon-button" data-action="horizontal-rule" aria-label="Insert horizontal rule">
               <i class="fa-solid fa-minus" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- add toolbar buttons for strikethrough, inline code, block quotes, and fenced code blocks
- support the new actions in the editor logic with helpful placeholders
- update the page title to reflect the active file name and unsaved state for better context

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d40614763083309a62133bd8d30bc6