### PR TITLE
Add strikethrough support for tilde syntax

### DIFF
--- a/app.js
+++ b/app.js
@@ -574,7 +574,7 @@ function updateCounts(content) {
 
 function renderInlineMarkdown(text) {
   const fragment = document.createDocumentFragment();
-  const pattern = /\*\*([^*]+)\*\*|\*([^*]+)\*/gu;
+  const pattern = /\*\*([^*]+)\*\*|\*([^*]+)\*|~~([^~]+)~~/gu;
   let lastIndex = 0;
   let match;
 
@@ -598,6 +598,13 @@ function renderInlineMarkdown(text) {
       emphasis.textContent = match[2];
       fragment.appendChild(emphasis);
       fragment.appendChild(document.createTextNode('*'));
+    } else if (match[3] !== undefined) {
+      fragment.appendChild(document.createTextNode('~~'));
+      const strike = document.createElement('span');
+      strike.classList.add('md-strike');
+      strike.textContent = match[3];
+      fragment.appendChild(strike);
+      fragment.appendChild(document.createTextNode('~~'));
     }
 
     lastIndex = pattern.lastIndex;

--- a/styles.css
+++ b/styles.css
@@ -538,6 +538,10 @@ main {
   font-style: italic;
 }
 
+.editor .md-strike {
+  text-decoration: line-through;
+}
+
 .status-bar {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- extend inline markdown renderer to recognize ~~strike~~ syntax and wrap the text in a strike element
- style rendered strike segments with a line-through decoration in the editor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4095a6010833082594dadae505563