### PR TITLE
Add theme toggle for light and dark modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,11 +24,23 @@
   <body>
     <header>
       <div class="inner">
-        <div class="app-brand">
-          <span class="brand-mark" aria-hidden="true">
-            <img src="icons/icon-1024.png" width="44" height="44" alt="" />
-          </span>
-          <h1>Mark's Markdown Editor</h1>
+        <div class="brand-row">
+          <div class="app-brand">
+            <span class="brand-mark" aria-hidden="true">
+              <img src="icons/icon-1024.png" width="44" height="44" alt="" />
+            </span>
+            <h1>Mark's Markdown Editor</h1>
+          </div>
+          <button
+            type="button"
+            class="theme-toggle"
+            id="theme-toggle"
+            aria-pressed="false"
+            aria-label="Switch to light mode"
+            title="Switch to light mode"
+          >
+            <i class="fa-solid fa-moon theme-toggle-icon" aria-hidden="true"></i>
+          </button>
         </div>
         <div class="toolbar-row">
           <div class="toolbar toolbar-surface formatting" role="toolbar" aria-label="Markdown formatting">

--- a/styles.css
+++ b/styles.css
@@ -71,6 +71,13 @@ header .inner {
   align-items: stretch;
 }
 
+.brand-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .app-brand {
   display: flex;
   align-items: center;
@@ -92,6 +99,46 @@ header .inner {
   display: block;
   width: 100%;
   height: 100%;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--border);
+  background: var(--button-bg);
+  color: var(--text);
+  box-shadow: 0 12px 24px var(--surface-shadow);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.theme-toggle:hover {
+  background: var(--button-bg-hover);
+  border-color: var(--button-border-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px var(--surface-shadow);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.theme-toggle i {
+  font-size: 1.1rem;
+}
+
+.theme-toggle[data-theme='dark'] i {
+  color: var(--accent);
+}
+
+.theme-toggle[data-theme='light'] i {
+  color: #facc15;
 }
 
 h1 {
@@ -1131,7 +1178,7 @@ header.legal-header .inner {
 }
 
 @media (prefers-color-scheme: light) {
-  :root {
+  :root:not([data-theme]) {
     --bg-gradient-start: #f8fafc;
     --bg-gradient-end: #e2e8f0;
     --surface: #ffffff;
@@ -1166,10 +1213,58 @@ header.legal-header .inner {
 
 }
 
+:root[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+  --bg-gradient-start: #f8fafc;
+  --bg-gradient-end: #e2e8f0;
+  --surface: #ffffff;
+  --surface-strong: #ffffff;
+  --header-bg: rgba(248, 250, 252, 0.85);
+  --input-bg: rgba(255, 255, 255, 0.95);
+  --text: #0f172a;
+  --text-muted: rgba(15, 23, 42, 0.6);
+  --text-subtle: rgba(15, 23, 42, 0.7);
+  --border: rgba(15, 23, 42, 0.12);
+  --button-bg: #f8fafc;
+  --button-bg-hover: #e2e8f0;
+  --button-border-hover: rgba(148, 163, 184, 0.35);
+  --overlay: rgba(15, 23, 42, 0.3);
+  --shadow: rgba(15, 23, 42, 0.08);
+  --surface-shadow: rgba(15, 23, 42, 0.1);
+  --strong-shadow: rgba(15, 23, 42, 0.12);
+  --editor-bg: #ffffff;
+  --editor-border: rgba(15, 23, 42, 0.12);
+  --editor-shadow: 0 18px 44px rgba(15, 23, 42, 0.1);
+  --table-border: rgba(15, 23, 42, 0.08);
+  --row-hover: rgba(56, 189, 248, 0.12);
+  --row-selected: rgba(56, 189, 248, 0.18);
+  --breadcrumb-text: rgba(15, 23, 42, 0.65);
+  --breadcrumb-separator: rgba(15, 23, 42, 0.35);
+  --breadcrumb-disabled: rgba(15, 23, 42, 0.4);
+  --danger-bg: rgba(248, 113, 113, 0.15);
+  --danger-border: rgba(248, 113, 113, 0.3);
+  --danger-text: #b91c1c;
+  --legal-intro-bg: rgba(15, 23, 42, 0.05);
+}
+
 @media (max-width: 768px) {
   header .inner {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .brand-row {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .theme-toggle {
+    align-self: center;
   }
 
   h1 {


### PR DESCRIPTION
## Summary
- add a dedicated theme toggle button with sun/moon iconography in the header
- persist user theme preference, update the document theme color, and react to system preference changes
- extend the stylesheet with data-theme overrides and responsive styling for the new control

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d41a6b84a883309d2adc844e734380