### PR TITLE
Fix File bar colors in light mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,13 @@
   --shadow: rgba(15, 23, 42, 0.4);
   --surface-shadow: rgba(15, 23, 42, 0.45);
   --strong-shadow: rgba(15, 23, 42, 0.7);
+  --drive-menu-label-bg: rgba(15, 23, 42, 0.55);
+  --drive-menu-label-border: rgba(148, 163, 184, 0.4);
+  --drive-menu-button-bg: rgba(15, 23, 42, 0.45);
+  --drive-menu-button-border: rgba(148, 163, 184, 0.28);
+  --drive-menu-icon-bg-disabled: rgba(15, 23, 42, 0.35);
+  --drive-menu-button-disabled-bg: rgba(15, 23, 42, 0.25);
+  --drive-menu-button-disabled-border: rgba(148, 163, 184, 0.22);
   --editor-bg: linear-gradient(170deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
   --editor-border: rgba(148, 163, 184, 0.45);
   --editor-shadow: 0 24px 55px var(--strong-shadow);
@@ -203,8 +210,8 @@ h1 {
   gap: 0.45rem;
   padding: 0.35rem 0.65rem;
   border-radius: 0.65rem;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: var(--drive-menu-label-bg);
+  border: 1px solid var(--drive-menu-label-border);
   text-transform: uppercase;
   font-size: 0.7rem;
   letter-spacing: 0.18em;
@@ -235,8 +242,8 @@ h1 {
   padding: 0.55rem 1rem;
   font-weight: 600;
   letter-spacing: 0.02em;
-  background: rgba(15, 23, 42, 0.45);
-  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: var(--drive-menu-button-bg);
+  border: 1px solid var(--drive-menu-button-border);
   border-radius: 0.7rem;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 10px 20px rgba(15, 23, 42, 0.35);
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
@@ -295,14 +302,14 @@ h1 {
 }
 
 .toolbar.drive-actions .drive-button:disabled {
-  background: rgba(15, 23, 42, 0.25);
-  border-color: rgba(148, 163, 184, 0.22);
+  background: var(--drive-menu-button-disabled-bg);
+  border-color: var(--drive-menu-button-disabled-border);
   box-shadow: none;
 }
 
 .toolbar.drive-actions .drive-button:disabled .drive-icon {
   opacity: 0.65;
-  background: rgba(15, 23, 42, 0.35);
+  background: var(--drive-menu-icon-bg-disabled);
 }
 
 @media (max-width: 720px) {
@@ -1436,6 +1443,13 @@ header.legal-header .inner {
     --shadow: rgba(15, 23, 42, 0.08);
     --surface-shadow: rgba(15, 23, 42, 0.1);
     --strong-shadow: rgba(15, 23, 42, 0.12);
+    --drive-menu-label-bg: rgba(148, 163, 184, 0.18);
+    --drive-menu-label-border: rgba(148, 163, 184, 0.35);
+    --drive-menu-button-bg: rgba(148, 163, 184, 0.12);
+    --drive-menu-button-border: rgba(148, 163, 184, 0.28);
+    --drive-menu-icon-bg-disabled: rgba(148, 163, 184, 0.2);
+    --drive-menu-button-disabled-bg: rgba(148, 163, 184, 0.16);
+    --drive-menu-button-disabled-border: rgba(148, 163, 184, 0.24);
     --editor-bg: #ffffff;
     --editor-border: rgba(15, 23, 42, 0.12);
     --editor-shadow: 0 18px 44px rgba(15, 23, 42, 0.1);
@@ -1476,6 +1490,13 @@ header.legal-header .inner {
   --shadow: rgba(15, 23, 42, 0.08);
   --surface-shadow: rgba(15, 23, 42, 0.1);
   --strong-shadow: rgba(15, 23, 42, 0.12);
+  --drive-menu-label-bg: rgba(148, 163, 184, 0.18);
+  --drive-menu-label-border: rgba(148, 163, 184, 0.35);
+  --drive-menu-button-bg: rgba(148, 163, 184, 0.12);
+  --drive-menu-button-border: rgba(148, 163, 184, 0.28);
+  --drive-menu-icon-bg-disabled: rgba(148, 163, 184, 0.2);
+  --drive-menu-button-disabled-bg: rgba(148, 163, 184, 0.16);
+  --drive-menu-button-disabled-border: rgba(148, 163, 184, 0.24);
   --editor-bg: #ffffff;
   --editor-border: rgba(15, 23, 42, 0.12);
   --editor-shadow: 0 18px 44px rgba(15, 23, 42, 0.1);


### PR DESCRIPTION
## Summary
- introduce theme-aware CSS variables for the Drive "File" menu chrome
- apply light theme overrides so the menu matches light mode colors

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d82ab32344833083e1b4c3171da604