### PR TITLE
Tame File menu palette in light mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,20 @@
   --shadow: rgba(15, 23, 42, 0.4);
   --surface-shadow: rgba(15, 23, 42, 0.45);
   --strong-shadow: rgba(15, 23, 42, 0.7);
+  --drive-menu-label-bg: rgba(15, 23, 42, 0.55);
+  --drive-menu-label-border: rgba(148, 163, 184, 0.4);
+  --drive-menu-button-bg: rgba(15, 23, 42, 0.45);
+  --drive-menu-button-border: rgba(148, 163, 184, 0.28);
+  --drive-menu-icon-bg-disabled: rgba(15, 23, 42, 0.35);
+  --drive-menu-button-disabled-bg: rgba(15, 23, 42, 0.25);
+  --drive-menu-button-disabled-border: rgba(148, 163, 184, 0.22);
+  --drive-menu-surface: linear-gradient(140deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.72));
+  --drive-menu-border: rgba(148, 163, 184, 0.45);
+  --drive-menu-glow: radial-gradient(circle at top, rgba(56, 189, 248, 0.22), transparent 55%);
+  --drive-menu-divider: linear-gradient(180deg, transparent, rgba(148, 163, 184, 0.45), transparent);
+  --drive-menu-icon-bg: rgba(14, 23, 42, 0.6);
+  --drive-menu-icon-shadow: rgba(15, 23, 42, 0.35);
+  --drive-menu-icon-shadow-hover: rgba(15, 23, 42, 0.4);
   --editor-bg: linear-gradient(170deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
   --editor-border: rgba(148, 163, 184, 0.45);
   --editor-shadow: 0 24px 55px var(--strong-shadow);
@@ -176,8 +190,8 @@ h1 {
   align-items: stretch;
   gap: 0.75rem;
   padding: 0.55rem 0.75rem;
-  background: linear-gradient(140deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.72));
-  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: var(--drive-menu-surface);
+  border: 1px solid var(--drive-menu-border);
   box-shadow: 0 20px 48px var(--surface-shadow);
   position: relative;
   overflow: hidden;
@@ -187,7 +201,7 @@ h1 {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.22), transparent 55%);
+  background: var(--drive-menu-glow);
   pointer-events: none;
   opacity: 0.9;
 }
@@ -203,8 +217,8 @@ h1 {
   gap: 0.45rem;
   padding: 0.35rem 0.65rem;
   border-radius: 0.65rem;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: var(--drive-menu-label-bg);
+  border: 1px solid var(--drive-menu-label-border);
   text-transform: uppercase;
   font-size: 0.7rem;
   letter-spacing: 0.18em;
@@ -220,7 +234,7 @@ h1 {
 .toolbar.drive-actions .drive-menu-divider {
   width: 1px;
   align-self: center;
-  background: linear-gradient(180deg, transparent, rgba(148, 163, 184, 0.45), transparent);
+  background: var(--drive-menu-divider);
   min-height: 2.75rem;
 }
 
@@ -235,8 +249,8 @@ h1 {
   padding: 0.55rem 1rem;
   font-weight: 600;
   letter-spacing: 0.02em;
-  background: rgba(15, 23, 42, 0.45);
-  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: var(--drive-menu-button-bg);
+  border: 1px solid var(--drive-menu-button-border);
   border-radius: 0.7rem;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 10px 20px rgba(15, 23, 42, 0.35);
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
@@ -272,16 +286,16 @@ h1 {
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 0.7rem;
-  background: rgba(14, 23, 42, 0.6);
+  background: var(--drive-menu-icon-bg);
   color: var(--accent);
   font-size: 0.95rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 6px 16px rgba(15, 23, 42, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 6px 16px var(--drive-menu-icon-shadow);
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .toolbar.drive-actions .drive-button:hover .drive-icon {
   background: rgba(56, 189, 248, 0.2);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), 0 12px 20px rgba(15, 23, 42, 0.4);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), 0 12px 20px var(--drive-menu-icon-shadow-hover);
 }
 
 .toolbar.drive-actions .drive-button.primary .drive-icon {
@@ -295,14 +309,14 @@ h1 {
 }
 
 .toolbar.drive-actions .drive-button:disabled {
-  background: rgba(15, 23, 42, 0.25);
-  border-color: rgba(148, 163, 184, 0.22);
+  background: var(--drive-menu-button-disabled-bg);
+  border-color: var(--drive-menu-button-disabled-border);
   box-shadow: none;
 }
 
 .toolbar.drive-actions .drive-button:disabled .drive-icon {
   opacity: 0.65;
-  background: rgba(15, 23, 42, 0.35);
+  background: var(--drive-menu-icon-bg-disabled);
 }
 
 @media (max-width: 720px) {
@@ -1436,6 +1450,20 @@ header.legal-header .inner {
     --shadow: rgba(15, 23, 42, 0.08);
     --surface-shadow: rgba(15, 23, 42, 0.1);
     --strong-shadow: rgba(15, 23, 42, 0.12);
+    --drive-menu-label-bg: rgba(148, 163, 184, 0.18);
+    --drive-menu-label-border: rgba(148, 163, 184, 0.35);
+    --drive-menu-button-bg: rgba(148, 163, 184, 0.12);
+    --drive-menu-button-border: rgba(148, 163, 184, 0.28);
+    --drive-menu-icon-bg-disabled: rgba(148, 163, 184, 0.2);
+    --drive-menu-button-disabled-bg: rgba(148, 163, 184, 0.16);
+    --drive-menu-button-disabled-border: rgba(148, 163, 184, 0.24);
+    --drive-menu-surface: rgba(255, 255, 255, 0.95);
+    --drive-menu-border: rgba(148, 163, 184, 0.22);
+    --drive-menu-glow: radial-gradient(circle at top, rgba(148, 163, 184, 0.12), transparent 55%);
+    --drive-menu-divider: linear-gradient(180deg, transparent, rgba(148, 163, 184, 0.28), transparent);
+    --drive-menu-icon-bg: rgba(226, 232, 240, 0.85);
+    --drive-menu-icon-shadow: rgba(15, 23, 42, 0.16);
+    --drive-menu-icon-shadow-hover: rgba(15, 23, 42, 0.22);
     --editor-bg: #ffffff;
     --editor-border: rgba(15, 23, 42, 0.12);
     --editor-shadow: 0 18px 44px rgba(15, 23, 42, 0.1);
@@ -1476,6 +1504,20 @@ header.legal-header .inner {
   --shadow: rgba(15, 23, 42, 0.08);
   --surface-shadow: rgba(15, 23, 42, 0.1);
   --strong-shadow: rgba(15, 23, 42, 0.12);
+  --drive-menu-label-bg: rgba(148, 163, 184, 0.18);
+  --drive-menu-label-border: rgba(148, 163, 184, 0.35);
+  --drive-menu-button-bg: rgba(148, 163, 184, 0.12);
+  --drive-menu-button-border: rgba(148, 163, 184, 0.28);
+  --drive-menu-icon-bg-disabled: rgba(148, 163, 184, 0.2);
+  --drive-menu-button-disabled-bg: rgba(148, 163, 184, 0.16);
+  --drive-menu-button-disabled-border: rgba(148, 163, 184, 0.24);
+  --drive-menu-surface: rgba(255, 255, 255, 0.95);
+  --drive-menu-border: rgba(148, 163, 184, 0.22);
+  --drive-menu-glow: radial-gradient(circle at top, rgba(148, 163, 184, 0.12), transparent 55%);
+  --drive-menu-divider: linear-gradient(180deg, transparent, rgba(148, 163, 184, 0.28), transparent);
+  --drive-menu-icon-bg: rgba(226, 232, 240, 0.85);
+  --drive-menu-icon-shadow: rgba(15, 23, 42, 0.16);
+  --drive-menu-icon-shadow-hover: rgba(15, 23, 42, 0.22);
   --editor-bg: #ffffff;
   --editor-border: rgba(15, 23, 42, 0.12);
   --editor-shadow: 0 18px 44px rgba(15, 23, 42, 0.1);


### PR DESCRIPTION
## Summary
- flatten the light theme File toolbar surface to a neutral surface color instead of a blue gradient
- soften the File toolbar glow and border to match the surrounding chrome in light mode

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d82ab32344833083e1b4c3171da604