### PR TITLE
Restructure Drive dropdown buttons into responsive grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,23 @@
         </div>
         <div class="toolbar-row">
           <div class="toolbar toolbar-surface formatting" role="toolbar" aria-label="Markdown formatting">
+            <div class="file-menu" id="file-menu">
+              <button
+                type="button"
+                class="secondary-button file-menu-toggle"
+                id="file-menu-toggle"
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-controls="file-menu-dropdown"
+                title="File actions"
+              >
+                <span class="file-menu-toggle-icon" aria-hidden="true">
+                  <i class="fa-solid fa-bars"></i>
+                </span>
+                <span class="button-label">File</span>
+                <i class="fa-solid fa-chevron-down file-menu-caret" aria-hidden="true"></i>
+              </button>
+            </div>
             <button
               type="button"
               class="icon-button"
@@ -121,14 +138,25 @@
               <span class="button-label">HTML</span>
             </button>
           </div>
-          <div class="toolbar toolbar-surface drive-actions" role="group" aria-label="Google Drive actions">
-            <div class="drive-menu-label" aria-hidden="true">
-              <i class="fa-solid fa-bars" aria-hidden="true"></i>
-              <span>File</span>
+          <div
+            class="toolbar toolbar-surface drive-actions file-menu-dropdown"
+            id="file-menu-dropdown"
+            role="menu"
+            hidden
+          >
+            <div class="drive-menu-header">
+              <div class="drive-menu-label" aria-hidden="true">
+                <i class="fa-solid fa-folder-tree" aria-hidden="true"></i>
+                <span>Drive</span>
+              </div>
             </div>
-            <div class="drive-menu-divider" aria-hidden="true"></div>
-            <div class="drive-menu-group" role="none">
-              <button type="button" class="secondary-button drive-button" id="drive-sign-in">
+            <div class="drive-menu-grid" role="none">
+              <button
+                type="button"
+                class="secondary-button drive-button"
+                id="drive-sign-in"
+                role="menuitem"
+              >
                 <span class="drive-icon" aria-hidden="true">
                   <i class="fa-brands fa-google-drive"></i>
                 </span>
@@ -138,6 +166,7 @@
                 type="button"
                 class="secondary-button drive-button"
                 id="drive-sign-out"
+                role="menuitem"
                 disabled
                 aria-disabled="true"
               >
@@ -146,22 +175,37 @@
                 </span>
                 <span class="button-label">Sign out</span>
               </button>
-            </div>
-            <div class="drive-menu-divider" aria-hidden="true"></div>
-            <div class="drive-menu-group" role="none">
-              <button type="button" class="secondary-button drive-button" id="drive-open" disabled>
+              <button
+                type="button"
+                class="secondary-button drive-button"
+                id="drive-open"
+                role="menuitem"
+                disabled
+              >
                 <span class="drive-icon" aria-hidden="true">
                   <i class="fa-solid fa-folder-open"></i>
                 </span>
                 <span class="button-label">Open</span>
               </button>
-              <button type="button" class="primary drive-button" id="drive-save" disabled>
+              <button
+                type="button"
+                class="primary drive-button"
+                id="drive-save"
+                role="menuitem"
+                disabled
+              >
                 <span class="drive-icon" aria-hidden="true">
                   <i class="fa-solid fa-cloud-arrow-up"></i>
                 </span>
                 <span class="button-label">Save</span>
               </button>
-              <button type="button" class="secondary-button drive-button" id="drive-save-as" disabled>
+              <button
+                type="button"
+                class="secondary-button drive-button"
+                id="drive-save-as"
+                role="menuitem"
+                disabled
+              >
                 <span class="drive-icon" aria-hidden="true">
                   <i class="fa-solid fa-file-export"></i>
                 </span>

--- a/styles.css
+++ b/styles.css
@@ -182,14 +182,101 @@ h1 {
 }
 
 .toolbar.formatting {
-  justify-content: center;
+  justify-content: flex-start;
+  align-items: center;
+  position: relative;
 }
 
-.toolbar.drive-actions {
+.file-menu {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  margin-right: 0.5rem;
+}
+
+.file-menu-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding-inline: 0.85rem 0.9rem;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.file-menu-toggle:hover {
+  transform: translateY(-1px);
+}
+
+.file-menu-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.file-menu-toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 0.55rem;
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--accent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.file-menu-caret {
+  font-size: 0.7rem;
+  opacity: 0.85;
+  transition: transform 0.2s ease;
+}
+
+.file-menu[data-open='true'] .file-menu-caret {
+  transform: rotate(180deg);
+}
+
+.file-menu-dropdown {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 1.25rem;
+  margin-top: 0.35rem;
+  border-radius: 1rem;
+}
+
+.file-menu-dropdown.toolbar.drive-actions {
+  flex-direction: row;
+  align-items: stretch;
+  row-gap: 1.25rem;
+  column-gap: 1.5rem;
+}
+
+.file-menu-dropdown[hidden] {
+  display: none !important;
+}
+
+.file-menu-dropdown .drive-menu-header {
+  flex: 1 1 100%;
+  display: flex;
   justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 0.35rem;
+}
+
+
+.file-menu-dropdown .drive-menu-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+
+
+.toolbar.drive-actions {
+  flex-direction: column;
   align-items: stretch;
   gap: 0.75rem;
-  padding: 0.55rem 0.75rem;
+  padding: 0.75rem;
   background: var(--drive-menu-surface);
   border: 1px solid var(--drive-menu-border);
   box-shadow: 0 20px 48px var(--surface-shadow);
@@ -231,17 +318,8 @@ h1 {
   opacity: 0.85;
 }
 
-.toolbar.drive-actions .drive-menu-divider {
-  width: 1px;
-  align-self: center;
-  background: var(--drive-menu-divider);
-  min-height: 2.75rem;
-}
-
-.toolbar.drive-actions .drive-menu-group {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
+.toolbar.drive-actions .drive-menu-grid {
+  gap: 0.5rem;
 }
 
 .toolbar.drive-actions .drive-button {
@@ -320,29 +398,21 @@ h1 {
 }
 
 @media (max-width: 720px) {
-  .toolbar.drive-actions {
-    justify-content: center;
-    padding: 0.6rem;
+  .file-menu {
+    width: 100%;
   }
 
-  .toolbar.drive-actions .drive-menu-label {
+  .file-menu-toggle {
     width: 100%;
     justify-content: center;
   }
 
-  .toolbar.drive-actions .drive-menu-divider {
-    display: none;
+  .file-menu-dropdown {
+    margin-top: 0.5rem;
   }
 
-  .toolbar.drive-actions .drive-menu-group {
-    width: 100%;
-    justify-content: center;
-    flex-wrap: wrap;
-  }
-
-  .toolbar.drive-actions .drive-button {
-    flex: 1 1 8rem;
-    justify-content: center;
+  .file-menu-dropdown .drive-menu-grid {
+    row-gap: 0.75rem;
   }
 }
 
@@ -736,6 +806,22 @@ main {
 }
 
 @media (min-width: 1024px) {
+  .file-menu-dropdown .drive-menu-header {
+    margin-bottom: 0.5rem;
+  }
+
+  .file-menu-dropdown .drive-menu-grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(8.75rem, 1fr));
+    column-gap: 1rem;
+    row-gap: 1.25rem;
+    align-items: stretch;
+  }
+
+  .file-menu-dropdown .drive-menu-grid .drive-button {
+    width: 100%;
+  }
+
   .editor-layout {
     display: grid;
     grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- flatten the Drive dropdown markup so the action buttons share a single grid container
- restyle the dropdown to stack vertically on small screens and span five responsive columns on desktop

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8f752b29c8330a65fa0f52118d672