### PR TITLE
Add offline file management to Drive dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
             <div class="drive-menu-header">
               <div class="drive-menu-label" aria-hidden="true">
                 <i class="fa-solid fa-folder-tree" aria-hidden="true"></i>
-                <span>Drive</span>
+                <span>Files</span>
               </div>
             </div>
             <div class="drive-menu-grid" role="none">


### PR DESCRIPTION
## Summary
- add local offline file storage helpers and surface offline folders within the existing file dialog
- update the Drive dialog to browse both offline and Drive locations with refreshed breadcrumbs, status messaging, and save logic
- enable quick offline saves, adjust menu labeling, and keep the file actions available even when Drive access is disabled

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d919e2a2608330bbd4973824e22de5