### PR TITLE
Keep file menu visible on mobile

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ const editorElements = {
   tocEmptyState: document.getElementById('toc-empty'),
   toolbarButtons: document.querySelectorAll('[data-action]'),
   formattingToolbar: document.getElementById('formatting-toolbar'),
+  formattingControls: document.getElementById('formatting-controls'),
   mobileToolbarToggle: document.getElementById('mobile-toolbar-toggle'),
   undoButton: document.querySelector('[data-action="undo"]'),
   redoButton: document.querySelector('[data-action="redo"]'),
@@ -1054,18 +1055,23 @@ function setupTouchEditorOptimizations() {
 
 function applyFormattingToolbarVisibility() {
   const toolbar = editorElements.formattingToolbar;
+  const controls = editorElements.formattingControls;
   const toggle = editorElements.mobileToolbarToggle;
-  if (!toolbar || !toggle) {
+  if (!toolbar || !toggle || !controls) {
     return;
   }
 
   const label = toggle.querySelector('.mobile-toolbar-label');
   const isMobile = mobileToolbarQuery ? mobileToolbarQuery.matches : false;
 
+  toolbar.hidden = false;
+
   if (!isMobile) {
-    toolbar.hidden = false;
+    controls.hidden = false;
+    controls.setAttribute('aria-hidden', 'false');
     toggle.hidden = true;
     toggle.setAttribute('aria-expanded', 'true');
+    toolbar.classList.remove('is-collapsed');
     if (label) {
       label.textContent = 'Hide formatting';
     }
@@ -1075,7 +1081,9 @@ function applyFormattingToolbarVisibility() {
 
   toggle.hidden = false;
   const expanded = !isFormattingToolbarCollapsed;
-  toolbar.hidden = isFormattingToolbarCollapsed;
+  controls.hidden = !expanded;
+  controls.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+  toolbar.classList.toggle('is-collapsed', !expanded);
   toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
   if (label) {
     label.textContent = expanded ? 'Hide formatting' : 'Show formatting';
@@ -1095,14 +1103,18 @@ function setFormattingToolbarCollapsed(collapsed) {
 
 function setupMobileToolbarToggle() {
   const toolbar = editorElements.formattingToolbar;
+  const controls = editorElements.formattingControls;
   const toggle = editorElements.mobileToolbarToggle;
-  if (!toolbar || !toggle) {
+  if (!toolbar || !toggle || !controls) {
     return;
   }
 
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
     toggle.hidden = true;
     toolbar.hidden = false;
+    controls.hidden = false;
+    controls.setAttribute('aria-hidden', 'false');
+    toolbar.classList.remove('is-collapsed');
     updateHeaderOffset();
     return;
   }

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
             class="mobile-toolbar-toggle"
             id="mobile-toolbar-toggle"
             aria-expanded="false"
-            aria-controls="formatting-toolbar"
+            aria-controls="formatting-controls"
           >
             <span class="mobile-toolbar-label">Show formatting</span>
             <i class="fa-solid fa-chevron-down mobile-toolbar-chevron" aria-hidden="true"></i>
@@ -76,82 +76,84 @@
                 <i class="fa-solid fa-chevron-down file-menu-caret" aria-hidden="true"></i>
               </button>
             </div>
-            <button
-              type="button"
-              class="icon-button"
-              data-action="undo"
-              aria-label="Undo"
-              title="Undo"
-              disabled
-            >
-              <i class="fa-solid fa-rotate-left" aria-hidden="true"></i>
-            </button>
-            <button
-              type="button"
-              class="icon-button"
-              data-action="redo"
-              aria-label="Redo"
-              title="Redo"
-              disabled
-            >
-              <i class="fa-solid fa-rotate-right" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="bold" aria-label="Bold">
-              <i class="fa-solid fa-bold" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="italic" aria-label="Italic">
-              <i class="fa-solid fa-italic" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="strikethrough" aria-label="Strikethrough">
-              <i class="fa-solid fa-strikethrough" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="inline-code" aria-label="Inline code">
-              <i class="fa-solid fa-code" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button heading-button" data-action="heading-1" aria-label="Heading level 1">
-              <span class="heading-icon" aria-hidden="true">H1</span>
-            </button>
-            <button type="button" class="icon-button heading-button" data-action="heading-2" aria-label="Heading level 2">
-              <span class="heading-icon" aria-hidden="true">H2</span>
-            </button>
-            <button type="button" class="icon-button heading-button" data-action="heading-3" aria-label="Heading level 3">
-              <span class="heading-icon" aria-hidden="true">H3</span>
-            </button>
-            <button type="button" class="icon-button" data-action="blockquote" aria-label="Block quote">
-              <i class="fa-solid fa-quote-right" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="link" aria-label="Insert link">
-              <i class="fa-solid fa-link" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="image" aria-label="Insert image">
-              <i class="fa-solid fa-image" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="ordered-list" aria-label="Ordered list">
-              <i class="fa-solid fa-list-ol" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="unordered-list" aria-label="Unordered list">
-              <i class="fa-solid fa-list-ul" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="table" aria-label="Insert table">
-              <i class="fa-solid fa-table" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="code-block" aria-label="Insert code block">
-              <i class="fa-solid fa-file-code" aria-hidden="true"></i>
-            </button>
-            <button type="button" class="icon-button" data-action="horizontal-rule" aria-label="Insert horizontal rule">
-              <i class="fa-solid fa-minus" aria-hidden="true"></i>
-            </button>
-            <button
-              type="button"
-              class="secondary-button mode-toggle"
-              id="editor-mode-toggle"
-              aria-pressed="false"
-              aria-label="Switch to HTML mode"
-              title="Switch to HTML mode"
-            >
-              <i class="fa-solid fa-code" aria-hidden="true"></i>
-              <span class="button-label">HTML</span>
-            </button>
+            <div class="formatting-controls" id="formatting-controls">
+              <button
+                type="button"
+                class="icon-button"
+                data-action="undo"
+                aria-label="Undo"
+                title="Undo"
+                disabled
+              >
+                <i class="fa-solid fa-rotate-left" aria-hidden="true"></i>
+              </button>
+              <button
+                type="button"
+                class="icon-button"
+                data-action="redo"
+                aria-label="Redo"
+                title="Redo"
+                disabled
+              >
+                <i class="fa-solid fa-rotate-right" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="bold" aria-label="Bold">
+                <i class="fa-solid fa-bold" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="italic" aria-label="Italic">
+                <i class="fa-solid fa-italic" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="strikethrough" aria-label="Strikethrough">
+                <i class="fa-solid fa-strikethrough" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="inline-code" aria-label="Inline code">
+                <i class="fa-solid fa-code" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button heading-button" data-action="heading-1" aria-label="Heading level 1">
+                <span class="heading-icon" aria-hidden="true">H1</span>
+              </button>
+              <button type="button" class="icon-button heading-button" data-action="heading-2" aria-label="Heading level 2">
+                <span class="heading-icon" aria-hidden="true">H2</span>
+              </button>
+              <button type="button" class="icon-button heading-button" data-action="heading-3" aria-label="Heading level 3">
+                <span class="heading-icon" aria-hidden="true">H3</span>
+              </button>
+              <button type="button" class="icon-button" data-action="blockquote" aria-label="Block quote">
+                <i class="fa-solid fa-quote-right" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="link" aria-label="Insert link">
+                <i class="fa-solid fa-link" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="image" aria-label="Insert image">
+                <i class="fa-solid fa-image" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="ordered-list" aria-label="Ordered list">
+                <i class="fa-solid fa-list-ol" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="unordered-list" aria-label="Unordered list">
+                <i class="fa-solid fa-list-ul" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="table" aria-label="Insert table">
+                <i class="fa-solid fa-table" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="code-block" aria-label="Insert code block">
+                <i class="fa-solid fa-file-code" aria-hidden="true"></i>
+              </button>
+              <button type="button" class="icon-button" data-action="horizontal-rule" aria-label="Insert horizontal rule">
+                <i class="fa-solid fa-minus" aria-hidden="true"></i>
+              </button>
+              <button
+                type="button"
+                class="secondary-button mode-toggle"
+                id="editor-mode-toggle"
+                aria-pressed="false"
+                aria-label="Switch to HTML mode"
+                title="Switch to HTML mode"
+              >
+                <i class="fa-solid fa-code" aria-hidden="true"></i>
+                <span class="button-label">HTML</span>
+              </button>
+            </div>
           </div>
           <div
             class="toolbar toolbar-surface drive-actions file-menu-dropdown"

--- a/styles.css
+++ b/styles.css
@@ -226,6 +226,15 @@ h1 {
   position: relative;
 }
 
+.formatting-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .file-menu {
   position: relative;
   display: flex;
@@ -472,7 +481,7 @@ h1 {
     padding: 0.5rem;
   }
 
-  .toolbar.formatting {
+  .formatting-controls {
     flex-wrap: nowrap;
     overflow-x: auto;
     overflow-y: hidden;
@@ -485,12 +494,16 @@ h1 {
     padding-right: 0.25rem;
   }
 
-  .toolbar.formatting > * {
+  .formatting-controls > * {
     flex: 0 0 auto;
     scroll-snap-align: start;
   }
 
-  .toolbar.formatting::-webkit-scrollbar {
+  .formatting-controls::-webkit-scrollbar {
+    display: none;
+  }
+
+  .toolbar.formatting.is-collapsed .formatting-controls {
     display: none;
   }
 
@@ -498,7 +511,7 @@ h1 {
     display: inline-flex;
   }
 
-  #formatting-toolbar[hidden] {
+  #formatting-controls[hidden] {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- wrap formatting controls in their own container so the File button stays visible while the rest of the toolbar can collapse on mobile
- update responsive styles to scroll only the formatting controls container and hide it when collapsed
- adjust mobile toolbar logic to toggle the new container instead of the entire toolbar, keeping accessibility attributes accurate

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e7bde218808330a2a1ddc1efff8d9e