### PR TITLE
Add least-privilege Google Drive Picker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,27 +28,29 @@ To work locally without a server, simply open `index.html` in a browser. For ful
 
 ## Google Drive configuration
 
-Google requires that you supply your own OAuth client ID (and optionally an API key) for Drive access. In production you should provide these credentials via a secure runtime configuration so they are never committed to the repository. The app attempts to load `/config/google-drive.json` (served by your hosting platform or backend) which should return JSON with `clientId` and `apiKey` fields.
+Google Drive sign-in requires a browser OAuth client ID. Opening arbitrary existing files through Google Picker also requires a browser-restricted API key and the Google Cloud project number (the Picker app ID). The app attempts to load `./config/google-drive.json`, which should return `clientId`, `apiKey`, and `appId` fields. Browser client IDs, restricted API keys, and project numbers are public identifiers in a static web app; never add an OAuth client secret.
 
 1. Visit the [Google Cloud Console](https://console.cloud.google.com/).
 2. Create a project (or choose an existing one) and enable the **Google Drive API**.
 3. Create credentials:
    - **OAuth 2.0 Client ID** (type: Web application). Add your GitHub Pages origin to the authorised JavaScript origins.
-   - **API key** *(optional)*. Restrict it to the origin that will host the editor and provide it at runtime alongside the client ID.
+   - **API key**. Restrict it to the Google Picker API and to the exact origins that host the editor.
+   - **Project number**. Find it under **IAM & Admin → Settings**; Google Picker calls this the app ID.
 4. Configure your hosting platform to expose the credentials at `/config/google-drive.json` or an equivalent authenticated endpoint. The payload should resemble:
 
    ```json
    {
      "clientId": "YOUR_CLIENT_ID",
-     "apiKey": "YOUR_OPTIONAL_API_KEY"
+     "apiKey": "YOUR_BROWSER_RESTRICTED_API_KEY",
+     "appId": "YOUR_GOOGLE_CLOUD_PROJECT_NUMBER"
    }
    ```
 
-   Never commit these values to source control.
-5. For local development you may still update the `<meta name="google-oauth-client-id">` tag inside `index.html` with your client ID so sign-in works when serving the files directly from disk.
-6. Deploy the updated files and configuration. When you open the editor, click **Sign in** to authorise Google Drive access, then use **Open**, **Save**, or **Save as** to work with Drive files.
+   Do not place an OAuth client secret in this file or anywhere in the browser app.
+5. For local development or static hosting without a config endpoint, you may provide `google-oauth-client-id`, `google-api-key`, and `google-cloud-project-number` meta tags in `index.html`. The project number can also be derived from the standard browser client ID format.
+6. Deploy the updated files and configuration. Click **Sign in**, then choose **Open → My Drive** to select an existing Markdown file with Google Picker. **Save** and **Save as** continue to create or update files authorised for this editor.
 
-> ⚠️ The app requests the `drive.file` and `drive.readonly` scopes. Ensure your OAuth consent screen is configured for external users if you plan to share the app.
+> The app requests only `drive.file`, a non-sensitive per-file scope. Google Picker grants the editor access only to files you explicitly select, while the editor can continue to update files it created.
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Google Drive sign-in requires a browser OAuth client ID. Opening arbitrary exist
    - **OAuth 2.0 Client ID** (type: Web application). Add your GitHub Pages origin to the authorised JavaScript origins.
    - **API key**. Restrict it to the Google Picker API and to the exact origins that host the editor.
    - **Project number**. Find it under **IAM & Admin → Settings**; Google Picker calls this the app ID.
-4. Configure your hosting platform to expose the credentials at `/config/google-drive.json` or an equivalent authenticated endpoint. The payload should resemble:
+4. Configure your hosting platform to expose the credentials at `./config/google-drive.json` (relative to the deployed app) or an equivalent endpoint. The payload should resemble:
 
    ```json
    {

--- a/app.js
+++ b/app.js
@@ -58,6 +58,7 @@ let turndownService = null;
 let lastSelection = { start: 0, end: 0 };
 let tokenClient = null;
 let gisReady = false;
+let pickerReady = false;
 let accessToken = null;
 let headerResizeObserver = null;
 let isFileMenuOpen = false;
@@ -134,14 +135,14 @@ let currentFileSource = null;
 let currentOfflineParentId = OFFLINE_ROOT_ID;
 
 const discoveryDocs = ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'];
-const scopes =
-  'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly';
+const scopes = 'https://www.googleapis.com/auth/drive.file';
 
-const driveConfigEndpoint = '/config/google-drive.json';
+const driveConfigEndpoint = './config/google-drive.json';
 
 let googleDriveConfig = {
   clientId: '',
-  apiKey: ''
+  apiKey: '',
+  appId: ''
 };
 
 const defaultMarkdown = `# Welcome to Mark's Markdown Editor
@@ -2457,14 +2458,30 @@ function navigateToParentFolder() {
   refreshDriveFileList({ folderId: parent.id, source: currentFolderSource });
 }
 
-function enterDriveFolder(folder) {
+async function enterDriveFolder(folder) {
   if (!folder?.id) {
     return;
   }
+  const folderSource = folder.source ?? currentFolderSource;
+  if (
+    driveDialogMode === 'open' &&
+    folderSource === FILE_SOURCE_DRIVE &&
+    folder.id === DRIVE_ROOT_ID &&
+    isPickerConfigured()
+  ) {
+    closeDialog();
+    try {
+      await openGoogleDrivePicker();
+    } catch (error) {
+      openDialog('open');
+      showDriveError(error);
+    }
+    return;
+  }
   const name = folder.name || 'Untitled folder';
-  driveFolderPath = [...driveFolderPath, { id: folder.id, name, source: folder.source ?? currentFolderSource }];
+  driveFolderPath = [...driveFolderPath, { id: folder.id, name, source: folderSource }];
   currentDriveFolderId = folder.id;
-  currentFolderSource = folder.source ?? currentFolderSource;
+  currentFolderSource = folderSource;
   clearDriveSelection();
   refreshDriveFileList({ folderId: folder.id, source: currentFolderSource });
 }
@@ -2604,6 +2621,9 @@ async function loadGoogleDriveConfig() {
     if (typeof config.apiKey === 'string') {
       googleDriveConfig.apiKey = config.apiKey.trim();
     }
+    if (typeof config.appId === 'string') {
+      googleDriveConfig.appId = config.appId.trim();
+    }
   }
 
   if (!googleDriveConfig.clientId) {
@@ -2611,6 +2631,25 @@ async function loadGoogleDriveConfig() {
     const metaContent = meta?.content?.trim();
     if (metaContent) {
       googleDriveConfig.clientId = metaContent;
+    }
+  }
+
+  if (!googleDriveConfig.apiKey) {
+    const meta = document.querySelector('meta[name="google-api-key"]');
+    const metaContent = meta?.content?.trim();
+    if (metaContent && !metaContent.startsWith('YOUR_')) {
+      googleDriveConfig.apiKey = metaContent;
+    }
+  }
+
+  if (!googleDriveConfig.appId) {
+    const meta = document.querySelector('meta[name="google-cloud-project-number"]');
+    const metaContent = meta?.content?.trim();
+    if (metaContent && !metaContent.startsWith('YOUR_')) {
+      googleDriveConfig.appId = metaContent;
+    } else {
+      const projectNumberMatch = googleDriveConfig.clientId.match(/^(\d+)-/u);
+      googleDriveConfig.appId = projectNumberMatch?.[1] ?? '';
     }
   }
 
@@ -2626,15 +2665,28 @@ function isDriveConfigured() {
   return Boolean(googleDriveConfig.clientId && !googleDriveConfig.clientId.startsWith('YOUR_'));
 }
 
+function isPickerConfigured() {
+  return Boolean(
+    isDriveConfigured() &&
+      googleDriveConfig.apiKey &&
+      !googleDriveConfig.apiKey.startsWith('YOUR_') &&
+      googleDriveConfig.appId &&
+      !googleDriveConfig.appId.startsWith('YOUR_')
+  );
+}
+
 function updateDriveConfigMessage() {
   if (!editorElements.driveConfigStatus) {
     return;
   }
   const configured = isDriveConfigured();
+  const pickerConfigured = isPickerConfigured();
   const messageElement = editorElements.driveConfigMessage ?? editorElements.driveConfigStatus;
-  const message = configured
-    ? 'Google Drive credentials loaded. Sign in to browse Drive files alongside your offline drafts.'
-    : 'Provide Google Drive credentials via your secure runtime configuration to enable Drive sync. Offline drafts remain available even without Drive access.';
+  const message = !configured
+    ? 'Provide a Google OAuth client ID to enable Drive sync. Offline drafts remain available without Drive access.'
+    : pickerConfigured
+      ? 'Google Drive and Google Picker are configured. Sign in to open selected Drive files alongside your offline drafts.'
+      : 'Google Drive sign-in is configured. Add a browser-restricted API key to enable Google Picker for arbitrary existing files.';
 
   editorElements.driveConfigStatus.classList.toggle('configured', configured);
   editorElements.driveConfigStatus.dataset.state = configured ? 'configured' : 'missing';
@@ -2711,6 +2763,74 @@ async function waitForGis() {
       }
     };
     check();
+  });
+}
+
+async function waitForPicker() {
+  if (pickerReady && window.google?.picker) {
+    return;
+  }
+  await new Promise((resolve, reject) => {
+    let attempts = 0;
+    const check = () => {
+      if (pickerReady && window.google?.picker) {
+        resolve();
+        return;
+      }
+      attempts += 1;
+      if (attempts >= 100) {
+        reject(new Error('Google Picker failed to load.'));
+        return;
+      }
+      window.setTimeout(check, 100);
+    };
+    check();
+  });
+}
+
+async function openGoogleDrivePicker() {
+  if (!isPickerConfigured()) {
+    throw new Error(
+      'Add a browser-restricted Google API key to your Drive configuration before opening existing Drive files.'
+    );
+  }
+  await ensureDriveAccess({ promptUser: true });
+  await waitForPicker();
+
+  return new Promise((resolve, reject) => {
+    const markdownView = new google.picker.View(google.picker.ViewId.DOCS);
+    markdownView.setMimeTypes('text/plain,text/markdown');
+
+    const picker = new google.picker.PickerBuilder()
+      .addView(markdownView)
+      .setOAuthToken(accessToken)
+      .setDeveloperKey(googleDriveConfig.apiKey)
+      .setAppId(googleDriveConfig.appId)
+      .setOrigin(window.location.origin)
+      .setTitle('Open Markdown from Google Drive')
+      .setCallback(async (data) => {
+        const action = data?.[google.picker.Response.ACTION];
+        if (action === google.picker.Action.CANCEL) {
+          resolve(false);
+          return;
+        }
+        if (action !== google.picker.Action.PICKED) {
+          return;
+        }
+        const documents = data[google.picker.Response.DOCUMENTS] || [];
+        const document = documents[0];
+        const fileId = document?.[google.picker.Document.ID];
+        const fileName = document?.[google.picker.Document.NAME] || 'Untitled.md';
+        if (!fileId) {
+          reject(new Error('Google Picker did not return a file ID.'));
+          return;
+        }
+        await loadDriveFile(fileId, fileName);
+        resolve(true);
+      })
+      .build();
+
+    picker.setVisible(true);
   });
 }
 
@@ -3181,12 +3301,13 @@ window.onGapiLoaded = () => {
     return;
   }
 
-  gapi.load('client', {
+  gapi.load('client:picker', {
     callback: () => {
       gapiReady = true;
+      pickerReady = Boolean(window.google?.picker);
     },
     onerror: () => {
-      console.error('Failed to load Google API client library modules.');
+      console.error('Failed to load Google API client or Picker library modules.');
     }
   });
 };

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'markdown-editor-cache-v3';
+const CACHE_NAME = 'markdown-editor-cache-v4';
 const OFFLINE_ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## What changed

- replace the combined `drive.file drive.readonly` OAuth request with `drive.file` only
- load Google Picker with the existing Google API client
- route **Open → My Drive** through Picker so users explicitly choose existing Markdown files
- support Picker API key and Cloud project number configuration, including meta-tag fallbacks
- derive the project number from the browser OAuth client ID when possible
- use a deployment-relative config URL for GitHub Pages
- bump the service-worker cache to v4
- correct the README's browser credential and client-secret guidance

## Why

The previous token request included the restricted `drive.readonly` scope, which caused Google Advanced Protection to reject the app with `Error 400: policy_enforced`. Google recommends `drive.file` with Google Picker for user-selected file access.

## Impact

The editor no longer asks to read the user's entire Drive. It can open files explicitly selected in Picker and continue to create or update files authorised for the app. Offline drafts remain available through the existing file dialog.

Google Picker still needs a browser-restricted API key. The OAuth client ID and project number are already supported; no OAuth client secret is required or permitted in the browser app.

## Validation

- parsed the updated `app.js` and `service-worker.js` successfully
- confirmed `drive.readonly` is absent
- confirmed `drive.file` is the sole requested scope
- confirmed Picker module loading and `PickerBuilder` integration
- confirmed cache name is `markdown-editor-cache-v4`
- compared branch to `main`: 3 scoped files and no unrelated changes